### PR TITLE
shell: fix printing log when no log rules are provided

### DIFF
--- a/src/caelestia/subcommands/shell.py
+++ b/src/caelestia/subcommands/shell.py
@@ -27,7 +27,7 @@ class Command:
                 args.append("--log-rules", self.args.log_rules)
             if self.args.daemon:
                 args.append("-d")
-                subprocess.run(args)
+                subprocess.run(args, check=False)
             else:
                 shell = subprocess.Popen(args, stdout=subprocess.PIPE, universal_newlines=True)
                 for line in shell.stdout:
@@ -44,9 +44,10 @@ class Command:
         print(self.shell("ipc", "show"), end="")
 
     def print_log(self) -> None:
-        log = self.shell("log")
+        log_args = ["log"]
         if self.args.log_rules:
-            log.append("r", self.args.log_rules)
+            log_args.append("r", self.args.log_rules)
+        log = self.shell(*log_args)
         # FIXME: remove when logging rules are added/warning is removed
         for line in log.splitlines():
             if self.filter_log(line):

--- a/src/caelestia/subcommands/shell.py
+++ b/src/caelestia/subcommands/shell.py
@@ -44,7 +44,9 @@ class Command:
         print(self.shell("ipc", "show"), end="")
 
     def print_log(self) -> None:
-        log = self.shell("log", "-r", self.args.log_rules)
+        log = self.shell("log")
+        if self.args.log_rules:
+            log.append("r", self.args.log_rules)
         # FIXME: remove when logging rules are added/warning is removed
         for line in log.splitlines():
             if self.filter_log(line):


### PR DESCRIPTION
The default log rules were removed, but the print_log function still tries to add the log rules even if there aren't any, leading to `caelestia shell -l` not working.

This is just a small pr that adds a check.