### PR TITLE
User template system for color scheme

### DIFF
--- a/src/caelestia/utils/colour.py
+++ b/src/caelestia/utils/colour.py
@@ -1,4 +1,4 @@
-class Color:
+class Colour:
     _rgb_vals: tuple[int, ...]
     _hex_vals: tuple[str, ...]
 
@@ -17,12 +17,12 @@ class Color:
 
     @property
     def rgb(self) -> str:
-        return f"rgb({','.join(map(str,self._rgb_vals[:-1]))})"
+        return f"rgb({','.join(map(str, self._rgb_vals[:-1]))})"
 
     @property
     def rgbalpha(self) -> str:
-        return f"rgba({','.join(map(str,self._rgb_vals))})"
+        return f"rgba({','.join(map(str, self._rgb_vals))})"
 
 
-def get_dynamic_colours(colours: dict[str, str]) -> dict[str, Color]:
-    return {name: Color(code) for name, code in colours.items()}
+def get_dynamic_colours(colours: dict[str, str]) -> dict[str, Colour]:
+    return {name: Colour(code) for name, code in colours.items()}

--- a/src/caelestia/utils/colour.py
+++ b/src/caelestia/utils/colour.py
@@ -1,0 +1,28 @@
+class Color:
+    _rgb_vals: tuple[int, ...]
+    _hex_vals: tuple[str, ...]
+
+    def __init__(self, hex: str):
+        hex = hex.ljust(8, "f")
+        self._hex_vals = tuple(hex[i : i + 2] for i in range(0, 7, 2))
+        self._rgb_vals = tuple(int(h, 16) for h in self._hex_vals)
+
+    @property
+    def hex(self) -> str:
+        return "".join(self._hex_vals[:-1])
+
+    @property
+    def hexalpha(self) -> str:
+        return "".join(self._hex_vals)
+
+    @property
+    def rgb(self) -> str:
+        return f"rgb({','.join(map(str,self._rgb_vals[:-1]))})"
+
+    @property
+    def rgbalpha(self) -> str:
+        return f"rgba({','.join(map(str,self._rgb_vals))})"
+
+
+def get_dynamic_colours(colours: dict[str, str]) -> dict[str, Color]:
+    return {name: Color(code) for name, code in colours.items()}

--- a/src/caelestia/utils/paths.py
+++ b/src/caelestia/utils/paths.py
@@ -17,6 +17,8 @@ c_cache_dir = cache_dir / "caelestia"
 
 cli_data_dir = Path(__file__).parent.parent / "data"
 templates_dir = cli_data_dir / "templates"
+user_templates_dir = c_config_dir / "templates"
+theme_dir = c_state_dir / "theme"
 
 scheme_path = c_state_dir / "scheme.json"
 scheme_data_dir = cli_data_dir / "schemes"

--- a/src/caelestia/utils/theme.py
+++ b/src/caelestia/utils/theme.py
@@ -28,7 +28,7 @@ def gen_replace(colours: dict[str, str], template: Path, hash: bool = False) -> 
 
 
 def gen_replace_dynamic(colours: dict[str, str], template: Path) -> str:
-    def fill_color(match: re.Match) -> str:
+    def fill_colour(match: re.Match) -> str:
         data = match.group(1).strip().split(".")
         if len(data) != 2:
             return match.group()
@@ -41,7 +41,7 @@ def gen_replace_dynamic(colours: dict[str, str], template: Path) -> str:
     field = r"\{\{((?:(?!\{\{|\}\}).)*)\}\}"
     colours_dyn = get_dynamic_colours(colours)
     template_content = template.read_text()
-    template_filled = re.sub(field, fill_color, template_content)
+    template_filled = re.sub(field, fill_colour, template_content)
 
     return template_filled
 
@@ -164,6 +164,9 @@ def apply_qt(colours: dict[str, str], mode: str) -> None:
 
 
 def apply_user_templates(colours: dict[str, str]) -> None:
+    if not user_templates_dir.is_dir():
+        return
+
     for file in user_templates_dir.iterdir():
         if file.is_file():
             content = gen_replace_dynamic(colours, file)

--- a/src/caelestia/utils/theme.py
+++ b/src/caelestia/utils/theme.py
@@ -1,7 +1,9 @@
+import re
 import subprocess
 from pathlib import Path
 
-from caelestia.utils.paths import c_state_dir, config_dir, templates_dir
+from caelestia.utils.colour import get_dynamic_colours
+from caelestia.utils.paths import c_state_dir, config_dir, templates_dir, theme_dir, user_templates_dir
 
 
 def gen_conf(colours: dict[str, str]) -> str:
@@ -23,6 +25,25 @@ def gen_replace(colours: dict[str, str], template: Path, hash: bool = False) -> 
     for name, colour in colours.items():
         template = template.replace(f"{{{{ ${name} }}}}", f"#{colour}" if hash else colour)
     return template
+
+
+def gen_replace_dynamic(colours: dict[str, str], template: Path) -> str:
+    def fill_color(match: re.Match) -> str:
+        data = match.group(1).strip().split(".")
+        if len(data) != 2:
+            return match.group()
+        col, form = data
+        if col not in colours_dyn or not hasattr(colours_dyn[col], form):
+            return match.group()
+        return getattr(colours_dyn[col], form)
+
+    # match atomic {{ . }} pairs
+    field = r"\{\{((?:(?!\{\{|\}\}).)*)\}\}"
+    colours_dyn = get_dynamic_colours(colours)
+    template_content = template.read_text()
+    template_filled = re.sub(field, fill_color, template_content)
+
+    return template_filled
 
 
 def c2s(c: str, *i: list[int]) -> str:
@@ -142,6 +163,13 @@ def apply_qt(colours: dict[str, str], mode: str) -> None:
         write_file(config_dir / f"qt{ver}ct/qt{ver}ct.conf", conf)
 
 
+def apply_user_templates(colours: dict[str, str]) -> None:
+    for file in user_templates_dir.iterdir():
+        if file.is_file():
+            content = gen_replace_dynamic(colours, file)
+            write_file(theme_dir / file.name, content)
+
+
 def apply_colours(colours: dict[str, str], mode: str) -> None:
     apply_terms(gen_sequences(colours))
     apply_hypr(gen_conf(colours))
@@ -151,3 +179,4 @@ def apply_colours(colours: dict[str, str], mode: str) -> None:
     apply_btop(colours)
     apply_gtk(colours, mode)
     apply_qt(colours, mode)
+    apply_user_templates(colours)


### PR DESCRIPTION
Let user define templates to be filled with scheme color on switch:

- templates files are written in c_config_dir / templates
- on switch file is generated for each user template in c_state_dir /  theme
- placeholder must be in the format {{ colorname.format }} where colorname is the color defined by the scheme and format is the intended format (rgb, hex)
- supported formats can be extended flawlessly

should fix #32 