### PR TITLE
clipboard: add -r option to clear entire clipboard

### DIFF
--- a/src/caelestia/parser.py
+++ b/src/caelestia/parser.py
@@ -74,8 +74,13 @@ def parse_args() -> (argparse.ArgumentParser, argparse.Namespace):
     # Create parser for clipboard opts
     clipboard_parser = command_parser.add_parser("clipboard", help="open clipboard history")
     clipboard_parser.set_defaults(cls=clipboard.Command)
-    clipboard_parser.add_argument("-d", "--delete", action="store_true", help="delete from clipboard history")
-
+    clipboard_parser.add_argument(
+        "-d", "--delete", action="store_true", help="delete one item from clipboard history"
+    )
+    clipboard_parser.add_argument(
+        "-r", "--reset", action="store_true", help="clear entire clipboard history"
+    )
+    
     # Create parser for emoji-picker opts
     emoji_parser = command_parser.add_parser("emoji", help="emoji/glyph utilities")
     emoji_parser.set_defaults(cls=emoji.Command)

--- a/src/caelestia/subcommands/clipboard.py
+++ b/src/caelestia/subcommands/clipboard.py
@@ -1,6 +1,6 @@
+#!/usr/bin/env python3
 import subprocess
-from argparse import Namespace
-
+from argparse import ArgumentParser, Namespace
 
 class Command:
     args: Namespace
@@ -11,15 +11,35 @@ class Command:
     def run(self) -> None:
         clip = subprocess.check_output(["cliphist", "list"])
 
-        if self.args.delete:
-            args = ["--prompt=del > ", "--placeholder=Delete from clipboard"]
-        else:
-            args = ["--placeholder=Type to search clipboard"]
+        if self.args.reset:
+            entries = clip.splitlines()
+            for entry in entries:
+                subprocess.run(["cliphist", "delete"], input=entry)
+            print(f"Deleted {len(entries)} clipboard entries.")
+            return
 
-        chosen = subprocess.check_output(["fuzzel", "--dmenu", *args], input=clip)
+        if self.args.delete:
+            fuzzel_args = ["--prompt=del > ", "--placeholder=Delete from clipboard"]
+        else:
+            fuzzel_args = ["--placeholder=Type to search clipboard"]
+
+        chosen = subprocess.check_output(
+            ["fuzzel", "--dmenu", *fuzzel_args], input=clip
+        )
 
         if self.args.delete:
             subprocess.run(["cliphist", "delete"], input=chosen)
         else:
             decoded = subprocess.check_output(["cliphist", "decode"], input=chosen)
             subprocess.run(["wl-copy"], input=decoded)
+
+def main():
+    parser = ArgumentParser(description="Caelestia clipboard manager")
+    parser.add_argument("-d", "--delete", action="store_true", help="Delete selected clipboard entry")
+    parser.add_argument("-r", "--reset", action="store_true", help="Delete all clipboard entries")
+    args = parser.parse_args()
+
+    Command(args).run()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
**Summary:**

Adds "-r" argument to caelestia clipboard, allowing the user to clear all entries in it instead of just one when using "-d".

**Changes:**

- Edited clipboard.py to add -r functionality
- Edited parser.py to make sure -r is recognized

**Usage:**

caelestia clipboard -r

**Testing Status:** 
Ran on my own setup, should work since nothing core was changed.
