### PR TITLE
templates: add nvtop, htop, and cava support

### DIFF
--- a/src/caelestia/data/templates/cava.conf
+++ b/src/caelestia/data/templates/cava.conf
@@ -1,0 +1,57 @@
+# Cava Audio Visualizer Configuration Template
+# Optimized for smooth and responsive visualization
+
+[general]
+# Number of bars (20-200) - fewer bars = better performance
+bars = 64
+# Framerate (1-144) - higher = smoother but more CPU intensive
+framerate = 60
+
+[input]
+# Audio input method: pulse, alsa, fifo, or portaudio
+method = pulse
+# Audio device (leave as default for auto-detection)
+source = auto
+
+[output]
+# Output method: ncurses, terminal, raw, or circle
+method = ncurses
+# Terminal color scheme
+style = stereo
+
+[color]
+# Color gradient for bars using template variables
+gradient = 1
+gradient_count = 8
+gradient_color_1 = '{{ $green }}'
+gradient_color_2 = '{{ $teal }}'
+gradient_color_3 = '{{ $sky }}'
+gradient_color_4 = '{{ $sapphire }}'
+gradient_color_5 = '{{ $blue }}'
+gradient_color_6 = '{{ $lavender }}'
+gradient_color_7 = '{{ $mauve }}'
+gradient_color_8 = '{{ $maroon }}'
+
+[smoothing]
+# Noise reduction (0-100) - higher = smoother but less responsive
+# 77 is default, 85 provides good balance for smooth visualization
+noise_reduction = 85
+
+# Monstercat smoothing (0 or 1) - adds smoothing between adjacent bars
+monstercat = 1
+
+# Wave effect (0 or 1) - creates wave-like motion across bars
+waves = 0
+
+# Gravity (0-200) - controls how fast bars fall
+# 100 = normal gravity, 150 = faster fall, 50 = slower fall
+gravity = 120
+
+[eq]
+# Equalizer settings for frequency response
+# Lower frequencies tend to be louder, so reduce them slightly
+1 = 0.8
+2 = 0.9
+3 = 1.0
+4 = 1.1
+5 = 1.2

--- a/src/caelestia/data/templates/htop.theme
+++ b/src/caelestia/data/templates/htop.theme
@@ -1,0 +1,95 @@
+# HTOP Color Configuration Template
+# This template generates a custom htoprc configuration with themed colors
+# Colors are defined using terminal color codes (0-255) or RGB hex values
+
+# htoprc configuration with custom colors
+fields=0 48 17 18 38 39 40 2 46 47 49 1
+sort_key=46
+sort_direction=-1
+tree_sort_key=0
+tree_sort_direction=1
+hide_kernel_threads=1
+hide_userland_threads=0
+shadow_other_users=0
+show_thread_names=0
+show_program_path=1
+highlight_base_name=0
+highlight_deleted_exe=1
+highlight_megabytes=1
+highlight_threads=1
+highlight_changes=0
+highlight_changes_delay_secs=5
+find_comm_in_cmdline=1
+strip_exe_from_cmdline=1
+show_merged_command=0
+tree_view=0
+tree_view_always_by_pid=0
+all_branches_collapsed=0
+header_margin=1
+detailed_cpu_time=0
+cpu_count_from_one=0
+show_cpu_usage=1
+show_cpu_frequency=0
+show_cpu_temperature=0
+degree_fahrenheit=0
+update_process_names=0
+account_guest_in_cpu_meter=0
+color_scheme=6
+
+# Custom color definitions using template variables
+# Main interface colors
+color_background={{ $surface }}
+color_text={{ $onSurface }}
+color_highlight={{ $primary }}
+color_selected={{ $surfaceContainer }}
+
+# CPU meter colors (gradient)
+color_cpu_low={{ $green }}
+color_cpu_med={{ $yellow }}
+color_cpu_high={{ $red }}
+
+# Memory meter colors
+color_mem_used={{ $blue }}
+color_mem_buffers={{ $teal }}
+color_mem_cache={{ $sapphire }}
+color_mem_available={{ $green }}
+
+# Process list colors
+color_process_normal={{ $onSurface }}
+color_process_running={{ $green }}
+color_process_sleeping={{ $outline }}
+color_process_zombie={{ $red }}
+color_process_stopped={{ $yellow }}
+
+# Header and border colors
+color_header={{ $onSurfaceVariant }}
+color_border={{ $outline }}
+color_separator={{ $outlineVariant }}
+
+# Function key colors
+color_function_key={{ $tertiary }}
+color_function_desc={{ $onSurface }}
+
+# Tree view colors
+color_tree_line={{ $outline }}
+color_tree_collapsed={{ $primary }}
+color_tree_expanded={{ $secondary }}
+
+# Load average colors
+color_load_low={{ $green }}
+color_load_med={{ $yellow }}
+color_load_high={{ $red }}
+
+# Priority colors
+color_priority_high={{ $red }}
+color_priority_normal={{ $onSurface }}
+color_priority_low={{ $outline }}
+
+# Swap meter colors
+color_swap_used={{ $maroon }}
+color_swap_cache={{ $peach }}
+
+# Temperature colors (if enabled)
+color_temp_cool={{ $green }}
+color_temp_warm={{ $yellow }}
+color_temp_hot={{ $red }}

--- a/src/caelestia/data/templates/nvtop.colors
+++ b/src/caelestia/data/templates/nvtop.colors
@@ -1,0 +1,53 @@
+# NVTOP Color Configuration Template
+# Format: color_name = RGB_HEX_VALUE
+# Colors must be specified as 6-digit hex values without # prefix
+
+# Background colors
+background = {{ $surface }}
+selected_bg = {{ $surfaceContainer }}
+header_bg = {{ $surfaceVariant }}
+
+# Text colors
+text = {{ $onSurface }}
+selected_text = {{ $primary }}
+header_text = {{ $onSurfaceVariant }}
+inactive_text = {{ $outline }}
+
+# GPU utilization colors (gradient from low to high)
+gpu_util_low = {{ $green }}
+gpu_util_med = {{ $yellow }}
+gpu_util_high = {{ $red }}
+
+# Memory usage colors
+memory_low = {{ $teal }}
+memory_med = {{ $sapphire }}
+memory_high = {{ $blue }}
+
+# Temperature colors (cool to hot)
+temp_cool = {{ $green }}
+temp_warm = {{ $yellow }}
+temp_hot = {{ $red }}
+
+# Power usage colors
+power_low = {{ $green }}
+power_med = {{ $peach }}
+power_high = {{ $maroon }}
+
+# Process list colors
+process_normal = {{ $onSurface }}
+process_highlight = {{ $primary }}
+process_killed = {{ $red }}
+
+# Border and separator colors
+border = {{ $outline }}
+separator = {{ $outlineVariant }}
+
+# Chart and graph colors
+chart_line = {{ $tertiary }}
+chart_fill = {{ $surfaceContainer }}
+
+# Status indicators
+status_ok = {{ $green }}
+status_warning = {{ $yellow }}
+status_error = {{ $red }}
+status_info = {{ $blue }}

--- a/src/caelestia/utils/theme.py
+++ b/src/caelestia/utils/theme.py
@@ -149,6 +149,16 @@ def apply_btop(colours: dict[str, str]) -> None:
     subprocess.run(["killall", "-USR2", "btop"], stderr=subprocess.DEVNULL)
 
 
+def apply_nvtop(colours: dict[str, str]) -> None:
+    template = gen_replace(colours, templates_dir / "nvtop.colors", hash=True)
+    write_file(config_dir / "nvtop/nvtop.colors", template)
+
+
+def apply_htop(colours: dict[str, str]) -> None:
+    template = gen_replace(colours, templates_dir / "htop.theme", hash=True)
+    write_file(config_dir / "htop/htoprc", template)
+
+
 def apply_gtk(colours: dict[str, str], mode: str) -> None:
     template = gen_replace(colours, templates_dir / "gtk.css", hash=True)
     write_file(config_dir / "gtk-3.0/gtk.css", template)
@@ -187,10 +197,15 @@ general="Sans Serif,12,-1,5,400,0,0,0,0,0,0,0,0,0,0,1"
 
 def apply_warp(colours: dict[str, str], mode: str) -> None:
     warp_mode = "darker" if mode == "dark" else "lighter"
-    
+
     template = gen_replace(colours, templates_dir / "warp.yaml", hash=True)
     template = template.replace("{{ $warp_mode }}", warp_mode)
     write_file(data_dir / "warp-terminal/themes/caelestia.yaml", template)
+
+
+def apply_cava(colours: dict[str, str]) -> None:
+    template = gen_replace(colours, templates_dir / "cava.conf", hash=True)
+    write_file(config_dir / "cava/config", template)
 
 
 def apply_user_templates(colours: dict[str, str]) -> None:
@@ -224,10 +239,16 @@ def apply_colours(colours: dict[str, str], mode: str) -> None:
         apply_fuzzel(colours)
     if check("enableBtop"):
         apply_btop(colours)
+    if check("enableNvtop"):
+        apply_nvtop(colours)
+    if check("enableHtop"):
+        apply_htop(colours)
     if check("enableGtk"):
         apply_gtk(colours, mode)
     if check("enableQt"):
         apply_qt(colours, mode)
     if check("enableWarp"):
         apply_warp(colours, mode)
+    if check("enableCava"):
+        apply_cava(colours)
     apply_user_templates(colours)


### PR DESCRIPTION
## Summary
- Add nvtop color configuration support
- Add htop theme configuration support  
- Add cava audio visualizer configuration support

## Test plan
- [x] Test nvtop color theming works correctly
- [x] Test htop theme application
- [x] Test cava configuration generation