### PR TITLE
fix(recording): use appropriate recorder for NVIDIA GPUs

### DIFF
--- a/src/caelestia/subcommands/record.py
+++ b/src/caelestia/subcommands/record.py
@@ -78,7 +78,7 @@ class Command:
 
         recording_path.parent.mkdir(parents=True, exist_ok=True)
         proc = subprocess.Popen(
-            ["wl-screenrec", *args, "-f", recording_path],
+            [self.recorder, *args, "-f", recording_path],
             stderr=subprocess.PIPE,
             text=True,
             start_new_session=True,


### PR DESCRIPTION
Previously, the start() function always invoked 'wl-screenrec' regardless of detected GPU, which prevented recording on systems with NVIDIA GPUswhen 'wf-recorder' is available.

This change updates start() to launch the recorder stored in self.recorder, ensuring the correct recorder is used based on GPU detection.