### PR TITLE
fix(recording): Fix wf-recorder audio flag and improve process monito…

### DIFF
--- a/src/caelestia/subcommands/record.py
+++ b/src/caelestia/subcommands/record.py
@@ -5,7 +5,7 @@ import time
 from argparse import Namespace
 from datetime import datetime
 
-from caelestia.utils.notify import notify
+from caelestia.utils.notify import close_notification, notify
 from caelestia.utils.paths import recording_notif_path, recording_path, recordings_dir
 
 
@@ -67,18 +67,22 @@ class Command:
         if self.args.sound:
             sources = subprocess.check_output(["pactl", "list", "short", "sources"], text=True).splitlines()
             audio_source = None
+
             for source in sources:
                 if "RUNNING" in source:
                     audio_source = source.split()[1]
                     break
+
             # Fallback to IDLE source if no RUNNING source
             if not audio_source:
                 for source in sources:
                     if "IDLE" in source:
                         audio_source = source.split()[1]
                         break
+
             if not audio_source:
                 raise ValueError("No audio source found")
+
             if self.recorder == "wf-recorder":
                 args += [f"--audio={audio_source}"]
             else:
@@ -91,12 +95,15 @@ class Command:
             text=True,
             start_new_session=True,
         )
+
         notif = notify("-p", "Recording started", "Recording...")
         recording_notif_path.write_text(notif)
-        for _ in range(15): # 15 * 0.2 = 3 seconds
+
+        for _ in range(5):
             if proc.poll() is not None:
-                _, err = proc.communicate()
-                notify("Recording failed", f"Recording error: {err}")
+                if proc.returncode != 0:
+                    close_notification(notif)
+                    notify("Recording failed", f"Recording error: {proc.communicate()[1]}")
                 return
             time.sleep(0.2)
 
@@ -115,19 +122,7 @@ class Command:
 
         # Close start notification
         try:
-            notif = recording_notif_path.read_text()
-            subprocess.run(
-                [
-                    "gdbus",
-                    "call",
-                    "--session",
-                    "--dest=org.freedesktop.Notifications",
-                    "--object-path=/org/freedesktop/Notifications",
-                    "--method=org.freedesktop.Notifications.CloseNotification",
-                    notif,
-                ],
-                stdout=subprocess.DEVNULL,
-            )
+            close_notification(recording_notif_path.read_text())
         except IOError:
             pass
 

--- a/src/caelestia/utils/notify.py
+++ b/src/caelestia/utils/notify.py
@@ -3,3 +3,18 @@ import subprocess
 
 def notify(*args: list[str]) -> str:
     return subprocess.check_output(["notify-send", "-a", "caelestia-cli", *args], text=True).strip()
+
+
+def close_notification(id: str) -> None:
+    subprocess.run(
+        [
+            "gdbus",
+            "call",
+            "--session",
+            "--dest=org.freedesktop.Notifications",
+            "--object-path=/org/freedesktop/Notifications",
+            "--method=org.freedesktop.Notifications.CloseNotification",
+            id,
+        ],
+        stdout=subprocess.DEVNULL,
+    )


### PR DESCRIPTION
…ring

- Fix incorrect audio flag format for wf-recorder(Invalid whitespace) Changed from `-a <device>` to `--audio=<device>` as per wf-recorder docs: "Specify device like this: -a<device> or --audio=<device>"

- Add fallback to IDLE audio sources Audio sources are typically in IDLE state when no media is playing. Now falls back to IDLE sources if no RUNNING sources are found, ensuring audio capture works when recording starts during silence but media plays later.

- Improve process startup monitoring The 0.1s sleep was insufficient for reliable process detection on NVIDIA systems. Process would start and immediately die ~90% of the time when triggered via keybinds. Now shows immediate UI feedback then monitors for 3 seconds to ensure stable process startup while maintaining responsive user experience.