### PR TITLE
feat: add timer and shell restart scripts

### DIFF
--- a/src/caelestia/parser.py
+++ b/src/caelestia/parser.py
@@ -1,6 +1,6 @@
 import argparse
 
-from caelestia.subcommands import clipboard, emoji, record, resizer, scheme, screenshot, shell, timer, toggle, wallpaper
+from caelestia.subcommands import clipboard, emoji, record, resizer, rshell, scheme, screenshot, shell, timer, toggle, wallpaper
 from caelestia.utils.paths import wallpapers_dir
 from caelestia.utils.scheme import get_scheme_names, scheme_variants
 from caelestia.utils.wallpaper import get_wallpaper
@@ -133,5 +133,9 @@ def parse_args() -> (argparse.ArgumentParser, argparse.Namespace):
     timer_parser.add_argument("-l", "--list", action="store_true", help="list all running timers")
     timer_parser.add_argument("-s", "--show", type=int, metavar="INDEX", help="show remaining time for timer at INDEX")
     timer_parser.add_argument("-q", "--quit", type=int, metavar="INDEX", help="quit timer at INDEX")
+
+    # Create parser for rshell opts
+    rshell_parser = command_parser.add_parser("rshell", help="restart the caelestia shell")
+    rshell_parser.set_defaults(cls=rshell.Command)
 
     return parser, parser.parse_args()

--- a/src/caelestia/parser.py
+++ b/src/caelestia/parser.py
@@ -1,6 +1,6 @@
 import argparse
 
-from caelestia.subcommands import clipboard, emoji, record, resizer, scheme, screenshot, shell, toggle, wallpaper
+from caelestia.subcommands import clipboard, emoji, record, resizer, scheme, screenshot, shell, timer, toggle, wallpaper
 from caelestia.utils.paths import wallpapers_dir
 from caelestia.utils.scheme import get_scheme_names, scheme_variants
 from caelestia.utils.wallpaper import get_wallpaper
@@ -125,5 +125,13 @@ def parse_args() -> (argparse.ArgumentParser, argparse.Namespace):
     resizer_parser.add_argument("width", nargs="?", help="width to resize to")
     resizer_parser.add_argument("height", nargs="?", help="height to resize to")
     resizer_parser.add_argument("actions", nargs="?", help="comma-separated actions to apply (float,center,pip)")
+
+    # Create parser for timer opts
+    timer_parser = command_parser.add_parser("timer", help="manage timers")
+    timer_parser.set_defaults(cls=timer.Command)
+    timer_parser.add_argument("duration", nargs="?", help="set a timer for DURATION minutes")
+    timer_parser.add_argument("-l", "--list", action="store_true", help="list all running timers")
+    timer_parser.add_argument("-s", "--show", type=int, metavar="INDEX", help="show remaining time for timer at INDEX")
+    timer_parser.add_argument("-q", "--quit", type=int, metavar="INDEX", help="quit timer at INDEX")
 
     return parser, parser.parse_args()

--- a/src/caelestia/subcommands/rshell.py
+++ b/src/caelestia/subcommands/rshell.py
@@ -1,0 +1,25 @@
+import subprocess
+import os
+from argparse import Namespace
+
+
+class Command:
+    args: Namespace
+
+    def __init__(self, args: Namespace) -> None:
+        self.args = args
+
+    def run(self) -> None:
+        script_path = os.path.join(os.path.dirname(__file__), "scripts", "rshell")
+        
+        # Execute the rshell script
+        try:
+            result = subprocess.run([script_path], capture_output=True, text=True)
+            if result.stdout:
+                print(result.stdout, end='')
+            if result.stderr:
+                print(result.stderr, end='')
+            exit(result.returncode)
+        except Exception as e:
+            print(f"Error executing rshell script: {e}")
+            exit(1)

--- a/src/caelestia/subcommands/scripts/rshell
+++ b/src/caelestia/subcommands/scripts/rshell
@@ -1,0 +1,5 @@
+#!/bin/bash
+echo "Starting shell restart"
+qs -c caelestia kill
+sleep 3
+caelestia shell -d

--- a/src/caelestia/subcommands/scripts/timer
+++ b/src/caelestia/subcommands/scripts/timer
@@ -1,0 +1,192 @@
+#!/bin/bash
+
+# Directory to store timer information
+TIMER_DIR="$HOME/.timers"
+mkdir -p "$TIMER_DIR"
+
+# File to store timer PIDs, start times, and durations
+TIMER_FILE="$TIMER_DIR/timers"
+
+# Function to display help message
+show_help() {
+  echo "Usage: ti [OPTION] [ARGUMENT]"
+  echo "A simple timer script that sets timers and sends notifications."
+  echo ""
+  echo "Options:"
+  echo "  -h, --help          Display this help message and exit"
+  echo "  -l, --list          List all running timers"
+  echo "  -s, --show INDEX    Show remaining time for timer at INDEX"
+  echo "  -q, --quit INDEX    Quit timer at INDEX"
+  echo "  MINUTES             Set a timer for MINUTES"
+  echo ""
+  echo "Examples:"
+  echo "  ti 30             Set a 30-minute timer"
+  echo "  ti -l             List all running timers"
+  echo "  ti -s 0           Show remaining time for timer at index 0"
+  echo "  ti -q 0           Quit timer at index 0"
+  echo "  ti                Display this help message"
+  exit 0
+}
+
+# Function to clean up finished timers
+clean_timers() {
+  if [ ! -s "$TIMER_FILE" ]; then
+    return
+  fi
+
+  # Create a temporary file for active timers
+  temp_file=$(mktemp)
+  while IFS=: read -r pid start duration; do
+    if ps -p "$pid" > /dev/null; then
+      echo "$pid:$start:$duration" >> "$temp_file"
+    fi
+  done < "$TIMER_FILE"
+
+  # Replace the original file with the cleaned-up version
+  mv "$temp_file" "$TIMER_FILE"
+}
+
+# Function to quit a specific timer
+quit_timer() {
+  local index="$1"
+  local count=0
+  local found=0
+  local temp_file=$(mktemp)
+
+  # Clean up finished timers before quitting
+  clean_timers
+
+  # Read the timer file and process the specified index
+  while IFS=: read -r pid start duration; do
+    if [ "$count" -eq "$index" ] && ps -p "$pid" > /dev/null; then
+      found=1
+      kill "$pid" 2>/dev/null
+      echo "Timer $index has been terminated."
+    else
+      echo "$pid:$start:$duration" >> "$temp_file"
+    fi
+    ((count++))
+  done < "$TIMER_FILE"
+
+  # Update the timer file
+  mv "$temp_file" "$TIMER_FILE"
+
+  if [ "$found" -eq 0 ]; then
+    echo "Error: No timer found at index $index or timer has already finished."
+    exit 1
+  fi
+}
+
+# Function to display remaining time for a specific timer
+show_timer() {
+  local index="$1"
+  local count=0
+  local found=0
+
+  # Clean up finished timers before showing
+  clean_timers
+
+  # Read the timer file and process the specified index
+  while IFS=: read -r pid start duration; do
+    if [ "$count" -eq "$index" ] && ps -p "$pid" > /dev/null; then
+      found=1
+      current_time=$(date +%s)
+      elapsed=$(echo "$current_time - $start" | bc -l)
+      remaining=$(echo "$duration - $elapsed" | bc -l)
+      if [ "$(echo "$remaining > 0" | bc -l)" -eq 1 ]; then
+        minutes=$(echo "$remaining / 60" | bc -l | awk '{printf "%.2f", $0}')
+        echo "Timer $index: $minutes minutes remaining"
+      else
+        echo "Timer $index: Already finished"
+      fi
+      break
+    fi
+    ((count++))
+  done < "$TIMER_FILE"
+
+  if [ "$found" -eq 0 ]; then
+    echo "Error: No timer found at index $index or timer has already finished."
+    exit 1
+  fi
+}
+
+# Function to list all running timers
+list_timers() {
+  # Clean up finished timers before listing
+  clean_timers
+
+  if [ ! -s "$TIMER_FILE" ]; then
+    echo "No timers are currently running."
+    exit 0
+  fi
+
+  local count=0
+  while IFS=: read -r pid start duration; do
+    if ps -p "$pid" > /dev/null; then
+      minutes=$(echo "$duration / 60" | bc -l | awk '{printf "%.2f", $0}')
+      echo "Timer $count: Set for $minutes minutes"
+    fi
+    ((count++))
+  done < "$TIMER_FILE"
+}
+
+# Check for flags or no arguments
+case "$1" in
+  -h|--help)
+    show_help
+    ;;
+  -l|--list)
+    list_timers
+    ;;
+  -s|--show)
+    if [ -z "$2" ]; then
+      echo "Error: Please provide a timer index with -s or --show."
+      exit 1
+    fi
+    if ! [[ "$2" =~ ^[0-9]+$ ]]; then
+      echo "Error: Timer index must be a non-negative integer."
+      exit 1
+    fi
+    show_timer "$2"
+    ;;
+  -q|--quit)
+    if [ -z "$2" ]; then
+      echo "Error: Please provide a timer index with -q or --quit."
+      exit 1
+    fi
+    if ! [[ "$2" =~ ^[0-9]+$ ]]; then
+      echo "Error: Timer index must be a non-negative integer."
+      exit 1
+    fi
+    quit_timer "$2"
+    ;;
+  "")
+    show_help
+    ;;
+  *)
+    # Validate input is a positive number (integer or float)
+    minutes="$1"
+    if ! [[ "$minutes" =~ ^[0-9]*\.?[0-9]+$ ]] || [ "$(echo "$minutes <= 0" | bc -l)" -eq 1 ]; then
+      echo "Error: Please provide a positive number for minutes (e.g., 60 or 0.5)."
+      exit 1
+    fi
+
+    # Convert minutes to seconds for sleep (handles floats)
+    seconds=$(echo "$minutes * 60" | bc -l)
+
+    # Command to execute when timer finishes
+    notify_cmd="notify-send -u low -i dialog-information-symbolic 'Timer' '$minutes minute timer done!'"
+    sound_cmd="paplay /usr/share/sounds/freedesktop/stereo/complete.oga"
+
+    # Get current timestamp
+    start_time=$(date +%s)
+
+    # Run sleep in the background and trigger notification and sound
+    (sleep "$seconds" && eval "$notify_cmd" && eval "$sound_cmd") &
+
+    # Store PID, start time, and duration in the timer file
+    echo "$!:$start_time:$seconds" >> "$TIMER_FILE"
+
+    echo "Timer set for $minutes minutes ($seconds seconds). Notification and sound will trigger when done."
+    ;;
+esac

--- a/src/caelestia/subcommands/timer.py
+++ b/src/caelestia/subcommands/timer.py
@@ -16,16 +16,14 @@ class Command:
         cmd = [script_path]
         
         # Pass through all arguments from argparse to the script
-        if hasattr(self.args, 'help') and self.args.help:
-            cmd.extend(['-h'])
-        elif hasattr(self.args, 'list') and self.args.list:
+        if hasattr(self.args, 'list') and self.args.list:
             cmd.extend(['-l'])
         elif hasattr(self.args, 'show') and self.args.show is not None:
             cmd.extend(['-s', str(self.args.show)])
         elif hasattr(self.args, 'quit') and self.args.quit is not None:
             cmd.extend(['-q', str(self.args.quit)])
-        elif hasattr(self.args, 'minutes') and self.args.minutes is not None:
-            cmd.append(str(self.args.minutes))
+        elif hasattr(self.args, 'duration') and self.args.duration is not None:
+            cmd.append(str(self.args.duration))
         
         # Execute the timer script
         try:

--- a/src/caelestia/subcommands/timer.py
+++ b/src/caelestia/subcommands/timer.py
@@ -1,0 +1,164 @@
+import json
+import os
+import subprocess
+import time
+from argparse import Namespace
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from caelestia.utils.notify import notify
+
+
+class Command:
+    args: Namespace
+    config_dir: Path
+    timer_file: Path
+
+    def __init__(self, args: Namespace) -> None:
+        self.args = args
+        self.config_dir = Path.home() / ".config" / "caelestia"
+        self.config_dir.mkdir(parents=True, exist_ok=True)
+        self.timer_file = self.config_dir / "timers.json"
+
+    def run(self) -> None:
+        if self.args.list:
+            self.list_timers()
+        elif self.args.show is not None:
+            self.show_timer(self.args.show)
+        elif self.args.quit is not None:
+            self.quit_timer(self.args.quit)
+        elif self.args.duration:
+            self.start_timer(self.args.duration)
+        else:
+            print("Usage: caelestia timer <duration> | --list | --show <id> | --quit <id>")
+            print("Set a timer for <duration> minutes, or use options to manage existing timers.")
+
+    def load_timers(self) -> Dict:
+        """Load timers from JSON file, cleaning up finished ones."""
+        if not self.timer_file.exists():
+            return {"timers": []}
+        
+        try:
+            with open(self.timer_file, 'r') as f:
+                data = json.load(f)
+        except (json.JSONDecodeError, FileNotFoundError):
+            return {"timers": []}
+        
+        # Clean up finished timers
+        active_timers = []
+        for timer in data.get("timers", []):
+            try:
+                if self._is_process_running(timer["pid"]):
+                    active_timers.append(timer)
+            except (KeyError, ValueError):
+                continue
+        
+        data["timers"] = active_timers
+        self.save_timers(data)
+        return data
+
+    def save_timers(self, data: Dict) -> None:
+        """Save timers to JSON file."""
+        with open(self.timer_file, 'w') as f:
+            json.dump(data, f, indent=2)
+
+    def _is_process_running(self, pid: int) -> bool:
+        """Check if a process is still running."""
+        try:
+            os.kill(pid, 0)
+            return True
+        except OSError:
+            return False
+
+    def start_timer(self, duration: str) -> None:
+        """Start a new timer."""
+        try:
+            minutes = float(duration)
+            if minutes <= 0:
+                print("Error: Please provide a positive number for minutes (e.g., 60 or 0.5).")
+                return
+        except ValueError:
+            print("Error: Please provide a valid number for minutes (e.g., 60 or 0.5).")
+            return
+
+        seconds = int(minutes * 60)
+        start_time = datetime.now().timestamp()
+        
+        # Create background command exactly matching original shell script
+        cmd = (
+            f"sleep {seconds} && "
+            f'notify-send -u low -i dialog-information-symbolic "Timer" "{minutes} minute timer done!" && '
+            f"paplay /usr/share/sounds/freedesktop/stereo/complete.oga"
+        )
+        
+        # Start background process
+        process = subprocess.Popen(["sh", "-c", cmd])
+        
+        # Load existing timers and add new one
+        data = self.load_timers()
+        timer_data = {
+            "pid": process.pid,
+            "start_time": start_time,
+            "duration": seconds,
+            "minutes": minutes
+        }
+        data["timers"].append(timer_data)
+        self.save_timers(data)
+        
+        print(f"Timer set for {minutes} minutes ({seconds} seconds). Notification and sound will trigger when done.")
+
+    def list_timers(self) -> None:
+        """List all running timers."""
+        data = self.load_timers()
+        timers = data.get("timers", [])
+        
+        if not timers:
+            print("No timers are currently running.")
+            return
+        
+        for i, timer in enumerate(timers):
+            minutes = timer.get("minutes", timer["duration"] / 60)
+            print(f"Timer {i}: Set for {minutes:.2f} minutes")
+
+    def show_timer(self, index: int) -> None:
+        """Show remaining time for a specific timer."""
+        data = self.load_timers()
+        timers = data.get("timers", [])
+        
+        if index < 0 or index >= len(timers):
+            print(f"Error: No timer found at index {index} or timer has already finished.")
+            return
+        
+        timer = timers[index]
+        current_time = datetime.now().timestamp()
+        elapsed = current_time - timer["start_time"]
+        remaining = timer["duration"] - elapsed
+        
+        if remaining > 0:
+            minutes = remaining / 60
+            print(f"Timer {index}: {minutes:.2f} minutes remaining")
+        else:
+            print(f"Timer {index}: Already finished")
+
+    def quit_timer(self, index: int) -> None:
+        """Quit a specific timer."""
+        data = self.load_timers()
+        timers = data.get("timers", [])
+        
+        if index < 0 or index >= len(timers):
+            print(f"Error: No timer found at index {index} or timer has already finished.")
+            return
+        
+        timer = timers[index]
+        
+        # Kill the process
+        try:
+            os.kill(timer["pid"], 9)  # SIGKILL
+            print(f"Timer {index} has been terminated.")
+        except OSError:
+            print(f"Timer {index} was already finished.")
+        
+        # Remove from list
+        del timers[index]
+        self.save_timers(data)

--- a/src/caelestia/subcommands/timer.py
+++ b/src/caelestia/subcommands/timer.py
@@ -1,164 +1,40 @@
-import json
-import os
 import subprocess
-import time
+import os
 from argparse import Namespace
-from datetime import datetime, timedelta
-from pathlib import Path
-from typing import Dict, List, Optional
-
-from caelestia.utils.notify import notify
 
 
 class Command:
     args: Namespace
-    config_dir: Path
-    timer_file: Path
 
     def __init__(self, args: Namespace) -> None:
         self.args = args
-        self.config_dir = Path.home() / ".config" / "caelestia"
-        self.config_dir.mkdir(parents=True, exist_ok=True)
-        self.timer_file = self.config_dir / "timers.json"
 
     def run(self) -> None:
-        if self.args.list:
-            self.list_timers()
-        elif self.args.show is not None:
-            self.show_timer(self.args.show)
-        elif self.args.quit is not None:
-            self.quit_timer(self.args.quit)
-        elif self.args.duration:
-            self.start_timer(self.args.duration)
-        else:
-            print("Usage: caelestia timer <duration> | --list | --show <id> | --quit <id>")
-            print("Set a timer for <duration> minutes, or use options to manage existing timers.")
-
-    def load_timers(self) -> Dict:
-        """Load timers from JSON file, cleaning up finished ones."""
-        if not self.timer_file.exists():
-            return {"timers": []}
+        script_path = os.path.join(os.path.dirname(__file__), "scripts", "timer")
         
+        # Build the command arguments
+        cmd = [script_path]
+        
+        # Pass through all arguments from argparse to the script
+        if hasattr(self.args, 'help') and self.args.help:
+            cmd.extend(['-h'])
+        elif hasattr(self.args, 'list') and self.args.list:
+            cmd.extend(['-l'])
+        elif hasattr(self.args, 'show') and self.args.show is not None:
+            cmd.extend(['-s', str(self.args.show)])
+        elif hasattr(self.args, 'quit') and self.args.quit is not None:
+            cmd.extend(['-q', str(self.args.quit)])
+        elif hasattr(self.args, 'minutes') and self.args.minutes is not None:
+            cmd.append(str(self.args.minutes))
+        
+        # Execute the timer script
         try:
-            with open(self.timer_file, 'r') as f:
-                data = json.load(f)
-        except (json.JSONDecodeError, FileNotFoundError):
-            return {"timers": []}
-        
-        # Clean up finished timers
-        active_timers = []
-        for timer in data.get("timers", []):
-            try:
-                if self._is_process_running(timer["pid"]):
-                    active_timers.append(timer)
-            except (KeyError, ValueError):
-                continue
-        
-        data["timers"] = active_timers
-        self.save_timers(data)
-        return data
-
-    def save_timers(self, data: Dict) -> None:
-        """Save timers to JSON file."""
-        with open(self.timer_file, 'w') as f:
-            json.dump(data, f, indent=2)
-
-    def _is_process_running(self, pid: int) -> bool:
-        """Check if a process is still running."""
-        try:
-            os.kill(pid, 0)
-            return True
-        except OSError:
-            return False
-
-    def start_timer(self, duration: str) -> None:
-        """Start a new timer."""
-        try:
-            minutes = float(duration)
-            if minutes <= 0:
-                print("Error: Please provide a positive number for minutes (e.g., 60 or 0.5).")
-                return
-        except ValueError:
-            print("Error: Please provide a valid number for minutes (e.g., 60 or 0.5).")
-            return
-
-        seconds = int(minutes * 60)
-        start_time = datetime.now().timestamp()
-        
-        # Create background command exactly matching original shell script
-        cmd = (
-            f"sleep {seconds} && "
-            f'notify-send -u low -i dialog-information-symbolic "Timer" "{minutes} minute timer done!" && '
-            f"paplay /usr/share/sounds/freedesktop/stereo/complete.oga"
-        )
-        
-        # Start background process
-        process = subprocess.Popen(["sh", "-c", cmd])
-        
-        # Load existing timers and add new one
-        data = self.load_timers()
-        timer_data = {
-            "pid": process.pid,
-            "start_time": start_time,
-            "duration": seconds,
-            "minutes": minutes
-        }
-        data["timers"].append(timer_data)
-        self.save_timers(data)
-        
-        print(f"Timer set for {minutes} minutes ({seconds} seconds). Notification and sound will trigger when done.")
-
-    def list_timers(self) -> None:
-        """List all running timers."""
-        data = self.load_timers()
-        timers = data.get("timers", [])
-        
-        if not timers:
-            print("No timers are currently running.")
-            return
-        
-        for i, timer in enumerate(timers):
-            minutes = timer.get("minutes", timer["duration"] / 60)
-            print(f"Timer {i}: Set for {minutes:.2f} minutes")
-
-    def show_timer(self, index: int) -> None:
-        """Show remaining time for a specific timer."""
-        data = self.load_timers()
-        timers = data.get("timers", [])
-        
-        if index < 0 or index >= len(timers):
-            print(f"Error: No timer found at index {index} or timer has already finished.")
-            return
-        
-        timer = timers[index]
-        current_time = datetime.now().timestamp()
-        elapsed = current_time - timer["start_time"]
-        remaining = timer["duration"] - elapsed
-        
-        if remaining > 0:
-            minutes = remaining / 60
-            print(f"Timer {index}: {minutes:.2f} minutes remaining")
-        else:
-            print(f"Timer {index}: Already finished")
-
-    def quit_timer(self, index: int) -> None:
-        """Quit a specific timer."""
-        data = self.load_timers()
-        timers = data.get("timers", [])
-        
-        if index < 0 or index >= len(timers):
-            print(f"Error: No timer found at index {index} or timer has already finished.")
-            return
-        
-        timer = timers[index]
-        
-        # Kill the process
-        try:
-            os.kill(timer["pid"], 9)  # SIGKILL
-            print(f"Timer {index} has been terminated.")
-        except OSError:
-            print(f"Timer {index} was already finished.")
-        
-        # Remove from list
-        del timers[index]
-        self.save_timers(data)
+            result = subprocess.run(cmd, capture_output=True, text=True)
+            if result.stdout:
+                print(result.stdout, end='')
+            if result.stderr:
+                print(result.stderr, end='')
+            exit(result.returncode)
+        except Exception as e:
+            print(f"Error executing timer script: {e}")
+            exit(1)


### PR DESCRIPTION
Hi, I'm proposing an addition of a pretty simple little timer script I made and found very useful that uses the notify-send feature that is built into the shell, it allows the user to set a timer that will play a sound when it goes off and also send a notification to the screen. The user can specify the number of minutes with "caelestia timer [minutes]" and view the time left in a timer, quit the timer, and view all running timers with simple commands. There's a Python script acting as a wrapper for the shell script, which is in subcommands/scripts/.

There's also a suuuper simple "rshell" command that allows the user to easily restart the shell - for example, when installing a new app, and also a wrapper Python script.