### PR TITLE
fix: special workspace toggle for IPC-spawned windows

### DIFF
--- a/src/caelestia/subcommands/toggle.py
+++ b/src/caelestia/subcommands/toggle.py
@@ -113,12 +113,15 @@ class Command:
             return
 
         spawned = False
+        needs_toggle = False
         if self.args.workspace in self.cfg:
             for client in self.cfg[self.args.workspace].values():
                 if "enable" in client and client["enable"] and self.handle_client_config(client):
                     spawned = True
+                    if client.get("spawn_then_toggle"):
+                        needs_toggle = True
 
-        if not spawned:
+        if not spawned or needs_toggle:
             hypr.dispatch("togglespecialworkspace", self.args.workspace)
 
     def get_clients(self) -> list[dict[str, Any]]:


### PR DESCRIPTION
## Summary

This PR fixes an issue where windows spawned through IPC (for example, `caelestia shell controlCenter open`) do not end up on the intended special workspace.

## Problem

Some applications create their windows through IPC. In those cases, Hyprland's `[workspace special:X]` rule is not applied, causing the window to open on the currently focused workspace instead.

The existing logic only calls `togglespecialworkspace` when no client was spawned. As a result:

1. Running the command for the first time spawns the window, but does not toggle the special workspace.
2. Running the command again finds the existing window and finally toggles the special workspace.

## Solution

Introduce an optional `spawn_then_toggle` flag for clients.

When enabled, the workspace will be toggled even if the client was successfully spawned. This allows IPC-spawned windows to be moved to the intended special workspace immediately after creation while preserving the existing behavior for other clients.

### cli.json
```json
        "controlcenter": {
            "Caelestia Settings - Network": {
                "enable": true,
                "match": [{ "initialTitle": "Caelestia Settings - Network" }],
                "command": ["caelestia", "shell", "controlCenter", "open"],
                "move": true,
                "spawn_then_toggle": true
            }
        },

```

Fixed: #73