### PR TITLE
fix: add spawnThenToggle client option

### DIFF
--- a/src/caelestia/subcommands/toggle.py
+++ b/src/caelestia/subcommands/toggle.py
@@ -120,7 +120,7 @@ class Command:
                     spawned = True
                     # Windows spawned via IPC ignore the [workspace special:X] exec rule,
                     # so the workspace has to be toggled open explicitly after spawning
-                    if client.get("spawnThenToggle") or client.get("spawn_then_toggle"):
+                    if client.get("spawnThenToggle"):
                         toggle_after_spawn = True
 
         if not spawned or toggle_after_spawn:

--- a/src/caelestia/subcommands/toggle.py
+++ b/src/caelestia/subcommands/toggle.py
@@ -113,12 +113,17 @@ class Command:
             return
 
         spawned = False
+        toggle_after_spawn = False
         if self.args.workspace in self.cfg:
             for client in self.cfg[self.args.workspace].values():
                 if "enable" in client and client["enable"] and self.handle_client_config(client):
                     spawned = True
+                    # Windows spawned via IPC ignore the [workspace special:X] exec rule,
+                    # so the workspace has to be toggled open explicitly after spawning
+                    if client.get("spawnThenToggle") or client.get("spawn_then_toggle"):
+                        toggle_after_spawn = True
 
-        if not spawned:
+        if not spawned or toggle_after_spawn:
             hypr.dispatch("togglespecialworkspace", self.args.workspace)
 
     def get_clients(self) -> list[dict[str, Any]]:


### PR DESCRIPTION
Fixes #73

Windows spawned via IPC (e.g. `caelestia shell controlCenter open`) ignore the `[workspace special:X]` exec rule, so the first `caelestia toggle <ws>` spawns the window on the current workspace and never opens the special workspace; only the second toggle moves it there.

This adds a per-client `spawnThenToggle` option that dispatches `togglespecialworkspace` right after the client command is spawned, which is the approach Mestane tested and confirmed working in the issue thread.

```json
"controlcenter": {
    "Caelestia Settings": {
        "enable": true,
        "match": [{ "initialTitle": "Caelestia Settings" }],
        "command": ["caelestia", "shell", "controlCenter", "open"],
        "move": true,
        "spawnThenToggle": true
    }
}
```

Default behaviour is unchanged: without the option set, toggling works exactly as before.