### PR TITLE
feat(clipboard,screenshot): add --copy and --clear flags

### DIFF
--- a/completions/caelestia.fish
+++ b/completions/caelestia.fish
@@ -101,6 +101,7 @@ complete -c caelestia -n "$seen scheme && $seen set" -s 'v' -l 'variant' -d 'Set
 # Screenshot
 complete -c caelestia -n "$seen screenshot" -s 'r' -l 'region' -d 'Capture region'
 complete -c caelestia -n "$seen screenshot" -s 'f' -l 'freeze' -d 'Freeze while selecting region'
+complete -c caelestia -n "$seen screenshot" -s 'c' -l 'copy' -d 'Copy screenshot to clipboard instead of opening it'
 
 # Record
 complete -c caelestia -n "$seen record" -s 'r' -l 'region' -d 'Capture region'
@@ -108,7 +109,8 @@ complete -c caelestia -n "$seen record" -s 's' -l 'sound' -d 'Capture sound'
 complete -c caelestia -n "$seen record" -s 'c' -l 'clipboard' -d 'Copy recording path to clipboard'
 
 # Clipboard
-complete -c caelestia -n "$seen clipboard" -s 'd' -l 'delete' -d 'Delete from cliboard history'
+complete -c caelestia -n "$seen clipboard" -s 'd' -l 'delete' -d 'Delete from clipboard history'
+complete -c caelestia -n "$seen clipboard" -s 'c' -l 'clear' -d 'Clear clipboard history'
 
 # Wallpaper
 complete -c caelestia -n "$seen wallpaper" -s 'p' -l 'print' -d 'Print the scheme for a wallpaper' -rF

--- a/src/caelestia/parser.py
+++ b/src/caelestia/parser.py
@@ -64,6 +64,9 @@ def parse_args() -> tuple[argparse.ArgumentParser, argparse.Namespace]:
     screenshot_parser.add_argument(
         "-f", "--freeze", action="store_true", help="freeze the screen while selecting a region"
     )
+    screenshot_parser.add_argument(
+        "-c", "--copy", action="store_true", help="copy the screenshot to the clipboard instead of opening it"
+    )
 
     # Create parser for record opts
     record_parser = command_parser.add_parser("record", help="start a screen recording")
@@ -77,6 +80,7 @@ def parse_args() -> tuple[argparse.ArgumentParser, argparse.Namespace]:
     clipboard_parser = command_parser.add_parser("clipboard", help="open clipboard history")
     clipboard_parser.set_defaults(cls=clipboard.Command)
     clipboard_parser.add_argument("-d", "--delete", action="store_true", help="delete from clipboard history")
+    clipboard_parser.add_argument("-c", "--clear", action="store_true", help="clear the clipboard history")
 
     # Create parser for emoji-picker opts
     emoji_parser = command_parser.add_parser("emoji", help="emoji/glyph utilities")

--- a/src/caelestia/subcommands/clipboard.py
+++ b/src/caelestia/subcommands/clipboard.py
@@ -9,6 +9,10 @@ class Command:
         self.args = args
 
     def run(self) -> None:
+        if self.args.clear:
+            subprocess.run(["cliphist", "wipe"])
+            return
+
         clip = subprocess.check_output(["cliphist", "list"])
 
         if self.args.delete:

--- a/src/caelestia/subcommands/screenshot.py
+++ b/src/caelestia/subcommands/screenshot.py
@@ -21,11 +21,16 @@ class Command:
 
     def region(self) -> None:
         if self.args.region == "slurp":
-            subprocess.run(
-                ["qs", "-c", "caelestia", "ipc", "call", "picker", "openFreeze" if self.args.freeze else "open"]
-            )
+            func = "open" + ("Freeze" if self.args.freeze else "") + ("Clip" if self.args.copy else "")
+            subprocess.run(["qs", "-c", "caelestia", "ipc", "call", "picker", func])
         else:
             sc_data = subprocess.check_output(["grim", "-l", "0", "-g", self.args.region.strip(), "-"])
+
+            if self.args.copy:
+                subprocess.run(["wl-copy"], input=sc_data)
+                notify("Screenshot taken", "Screenshot copied to clipboard")
+                return
+
             swappy = subprocess.Popen(["swappy", "-f", "-"], stdin=subprocess.PIPE, start_new_session=True)
 
             # Ensure stdin is not None for the type checker


### PR DESCRIPTION
Closes #57, closes #65

Two small quality-of-life flags:

**`caelestia screenshot -c`/`--copy`** — copy the screenshot to the clipboard instead of opening it.
- For interactive region selection (`-r` with no value) this calls the shell picker's existing `openClip`/`openFreezeClip` IPC functions (combines with `-f`/`--freeze` as expected), so the behaviour matches the picker's clipboard-only mode.
- For an explicit region (`-r <geometry>`) the grim output is piped to `wl-copy` and a notification is sent, instead of opening swappy.
- Fullscreen screenshots already copy to the clipboard, so they are unchanged.

**`caelestia clipboard -c`/`--clear`** — runs `cliphist wipe` to clear the whole clipboard history, instead of deleting entries one by one with `-d`.

Fish completions are updated for both flags (and a `cliboard` typo in an existing completion description is fixed). No changes to existing behaviour.
