### PR TITLE
build: add fallback version for builds without git metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,11 @@ caelestia = "caelestia:main"
 [tool.hatch.version]
 source = "vcs"
 
+# Allow building from a source tree without git metadata (e.g. release
+# tarballs or AUR/paru build dirs), where hatch-vcs would otherwise fail
+[tool.hatch.version.raw-options]
+fallback_version = "0.0.0"
+
 [tool.hatch.build.targets.sdist]
 only-include = [
     "src",


### PR DESCRIPTION
Fixes #81

When the source tree has no git metadata (release tarballs, some AUR helper build setups), hatch-vcs cannot determine a version and the build backend aborts, so `python -m build --wheel` produces no `dist/` directory and the subsequent `python -m installer dist/*.whl` fails with `FileNotFoundError` This is exactly the paru log in the issue.

This adds setuptools-scm's `fallback_version` via `[tool.hatch.version.raw-options]`, so such builds succeed with version `0.0.0` instead of failing.

Verified by building the same tree with and without `.git`: without this change the no-git build errors out (`ERROR Backend subprocess exited when trying to invoke build_wheel`); with it, `caelestia-0.0.0-py3-none-any.whl` is produced. Builds from a proper git checkout are unaffected and keep their hatch-vcs derived version (the nix build is also unaffected as it sets `SETUPTOOLS_SCM_PRETEND_VERSION`).
