### PR TITLE
feat(scheme): allow per-wallpaper override of dynamic scheme

### DIFF
--- a/src/caelestia/utils/paths.py
+++ b/src/caelestia/utils/paths.py
@@ -27,6 +27,7 @@ theme_dir: Path = c_state_dir / "theme"
 scheme_path: Path = c_state_dir / "scheme.json"
 scheme_data_dir: Path = cli_data_dir / "schemes"
 scheme_cache_dir: Path = c_cache_dir / "schemes"
+custom_scheme_data_dir = c_config_dir / "schemes"
 
 wallpapers_dir: Path = Path(os.getenv("CAELESTIA_WALLPAPERS_DIR", pictures_dir / "Wallpapers"))
 wallpaper_path_path: Path = c_state_dir / "wallpaper/path.txt"

--- a/src/caelestia/utils/paths.py
+++ b/src/caelestia/utils/paths.py
@@ -27,7 +27,7 @@ theme_dir: Path = c_state_dir / "theme"
 scheme_path: Path = c_state_dir / "scheme.json"
 scheme_data_dir: Path = cli_data_dir / "schemes"
 scheme_cache_dir: Path = c_cache_dir / "schemes"
-custom_scheme_data_dir = c_config_dir / "schemes"
+manual_scheme_json = c_config_dir / "manual-schemes.json"
 
 wallpapers_dir: Path = Path(os.getenv("CAELESTIA_WALLPAPERS_DIR", pictures_dir / "Wallpapers"))
 wallpaper_path_path: Path = c_state_dir / "wallpaper/path.txt"

--- a/src/caelestia/utils/paths.py
+++ b/src/caelestia/utils/paths.py
@@ -27,7 +27,7 @@ theme_dir: Path = c_state_dir / "theme"
 scheme_path: Path = c_state_dir / "scheme.json"
 scheme_data_dir: Path = cli_data_dir / "schemes"
 scheme_cache_dir: Path = c_cache_dir / "schemes"
-manual_scheme_json = c_config_dir / "manual-schemes.json"
+scheme_override_json = c_config_dir / "scheme-overrides.json"
 
 wallpapers_dir: Path = Path(os.getenv("CAELESTIA_WALLPAPERS_DIR", pictures_dir / "Wallpapers"))
 wallpaper_path_path: Path = c_state_dir / "wallpaper/path.txt"

--- a/src/caelestia/utils/scheme.py
+++ b/src/caelestia/utils/scheme.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any
 
 from caelestia.utils.notify import notify
-from caelestia.utils.paths import atomic_dump, custom_scheme_data_dir, scheme_data_dir, scheme_path, wallpaper_path_path
+from caelestia.utils.paths import atomic_dump, manual_scheme_json, scheme_data_dir, scheme_path, wallpaper_path_path
 
 
 class Scheme:
@@ -182,26 +182,44 @@ class Scheme:
     def _update_colours_manual(self) -> None:
         # Look if there is a manual scheme for the current wallpaper.
         # If so, use it; otherwise use dynamic coloring.
-        wallpaper_name = ""
-        try:
-            with wallpaper_path_path.open("r") as file_read:
-                wallpaper_name = os.path.basename(file_read.read())
-        except (IOError, json.JSONDecodeError):
-            pass
 
-        custom_scheme_path = custom_scheme_data_dir.joinpath(f"{wallpaper_name}.txt")
-        try:
-            self._colours = read_colours_from_file(custom_scheme_path)
-        except Exception:
-            # Fallback to dynamic scheme if their is no user scheme for the current wallpaper.
+        def fallback_to_dynamic(message: str) -> None:
+            # Fallback to dynamic scheme if there is no user scheme for the current wallpaper.
             if self.notify:
                 notify(
                     "-u",
                     "normal",
-                    "Unable to set custom scheme",
-                    f"{custom_scheme_path} wasn't found, using dynamic scheme instead.",
+                    "Cannot set manual scheme",
+                    message,
                 )
             self._update_colours_dynamic()
+
+        wallpaper_name: str = ""
+        scheme_path: Path = Path()
+
+        try:
+            with wallpaper_path_path.open("r") as file_read:
+                wallpaper_name = os.path.basename(file_read.read())
+        except (IOError, json.JSONDecodeError):
+            fallback_to_dynamic("Cannot get wallpaper name.")
+            return
+
+        try:
+            with manual_scheme_json.open("r") as file_read:
+                schemes = json.load(file_read)
+                scheme_path = Path(schemes[wallpaper_name]).expanduser()
+        except (IOError, json.JSONDecodeError):
+            fallback_to_dynamic("Cannot open manual-scheme.json file.")
+            return
+        except KeyError:
+            fallback_to_dynamic(f"No manual scheme matching {wallpaper_name} found.")
+            return
+
+        try:
+            self._colours = read_colours_from_file(scheme_path)
+        except Exception:
+            fallback_to_dynamic(f"Failed to read colors from {scheme_path}.")
+            return
 
     def __str__(self) -> str:
         return (

--- a/src/caelestia/utils/scheme.py
+++ b/src/caelestia/utils/scheme.py
@@ -1,10 +1,11 @@
 import json
+import os
 import random
 from pathlib import Path
 from typing import Any
 
 from caelestia.utils.notify import notify
-from caelestia.utils.paths import atomic_dump, scheme_data_dir, scheme_path
+from caelestia.utils.paths import atomic_dump, custom_scheme_data_dir, scheme_data_dir, scheme_path, wallpaper_path_path
 
 
 class Scheme:
@@ -155,23 +156,52 @@ class Scheme:
 
     def _update_colours(self) -> None:
         if self.name == "dynamic":
-            from caelestia.utils.material import get_colours_for_image
-
-            try:
-                self._colours = get_colours_for_image()
-            except FileNotFoundError:
-                if self.notify:
-                    notify(
-                        "-u",
-                        "critical",
-                        "Unable to set dynamic scheme",
-                        "No wallpaper set. Please set a wallpaper via `caelestia wallpaper` before setting a dynamic scheme.",
-                    )
-                raise ValueError(
-                    "No wallpaper set. Please set a wallpaper via `caelestia wallpaper` before setting a dynamic scheme."
-                )
+            self._update_colours_dynamic()
+        elif self.name == "manual":
+            self._update_colours_manual()
         else:
             self._colours = read_colours_from_file(self.get_colours_path())
+
+    def _update_colours_dynamic(self) -> None:
+        from caelestia.utils.material import get_colours_for_image
+
+        try:
+            self._colours = get_colours_for_image()
+        except FileNotFoundError:
+            if self.notify:
+                notify(
+                    "-u",
+                    "critical",
+                    "Unable to set dynamic scheme",
+                    "No wallpaper set. Please set a wallpaper via `caelestia wallpaper` before setting a dynamic scheme.",
+                )
+            raise ValueError(
+                "No wallpaper set. Please set a wallpaper via `caelestia wallpaper` before setting a dynamic scheme."
+            )
+
+    def _update_colours_manual(self) -> None:
+        # Look if there is a manual scheme for the current wallpaper.
+        # If so, use it; otherwise use dynamic coloring.
+        wallpaper_name = ""
+        try:
+            with wallpaper_path_path.open("r") as file_read:
+                wallpaper_name = os.path.basename(file_read.read())
+        except (IOError, json.JSONDecodeError):
+            pass
+
+        custom_scheme_path = custom_scheme_data_dir.joinpath(f"{wallpaper_name}.txt")
+        try:
+            self._colours = read_colours_from_file(custom_scheme_path)
+        except Exception:
+            # Fallback to dynamic scheme if their is no user scheme for the current wallpaper.
+            if self.notify:
+                notify(
+                    "-u",
+                    "normal",
+                    "Unable to set custom scheme",
+                    f"{custom_scheme_path} wasn't found, using dynamic scheme instead.",
+                )
+            self._update_colours_dynamic()
 
     def __str__(self) -> str:
         return (
@@ -223,16 +253,20 @@ def get_scheme() -> Scheme:
 
 
 def get_scheme_names() -> list[str]:
-    return [*(f.name for f in scheme_data_dir.iterdir() if f.is_dir()), "dynamic"]
+    return [*(f.name for f in scheme_data_dir.iterdir() if f.is_dir()), "dynamic", "manual"]
 
 
 def get_scheme_flavours(name: str | None = None) -> list[str]:
     if name is None:
         name = get_scheme().name
 
-    return (
-        ["default", "hard"] if name == "dynamic" else [f.name for f in (scheme_data_dir / name).iterdir() if f.is_dir()]
-    )
+    if name == "dynamic":
+        return ["default", "hard"]
+    elif name == "manual":
+        # Shows the same flavors as dynamic as they are only used when falling back on dynamic scheme generation
+        return ["default", "hard"]
+    else:
+        return [f.name for f in (scheme_data_dir / name).iterdir() if f.is_dir()]
 
 
 def get_scheme_modes(name: str | None = None, flavour: str | None = None) -> list[str]:
@@ -242,6 +276,8 @@ def get_scheme_modes(name: str | None = None, flavour: str | None = None) -> lis
         flavour = flavour or scheme.flavour
 
     if name == "dynamic":
+        return ["light", "dark"]
+    elif name == "manual":
         return ["light", "dark"]
     else:
         return [f.stem for f in (scheme_data_dir / name / flavour).iterdir() if f.is_file()]

--- a/src/caelestia/utils/scheme.py
+++ b/src/caelestia/utils/scheme.py
@@ -1,6 +1,6 @@
 import json
-import os
 import random
+import re
 from pathlib import Path
 from typing import Any
 
@@ -180,11 +180,17 @@ class Scheme:
             )
 
     def _update_colours_manual(self) -> None:
-        # Look if there is a manual scheme for the current wallpaper.
-        # If so, use it; otherwise use dynamic coloring.
+        """Look if there is a manual scheme for the current wallpaper.
+
+        Logic:
+            - Open `manual_scheme_json`
+            - Look for exact wallpaper name match
+            - If none, look for regex wallpaper path match
+            - If none, use dynamic coloring.
+        """
 
         def fallback_to_dynamic(message: str) -> None:
-            # Fallback to dynamic scheme if there is no user scheme for the current wallpaper.
+            """Fallback to dynamic scheme if there is no user scheme for the current wallpaper."""
             if self.notify:
                 notify(
                     "-u",
@@ -194,25 +200,37 @@ class Scheme:
                 )
             self._update_colours_dynamic()
 
-        wallpaper_name: str = ""
+        wallpaper_path: Path = Path()
         scheme_path: Path = Path()
 
         try:
             with wallpaper_path_path.open("r") as file_read:
-                wallpaper_name = os.path.basename(file_read.read())
+                wallpaper_path = Path(file_read.read())
         except (IOError, json.JSONDecodeError):
             fallback_to_dynamic("Cannot get wallpaper name.")
             return
 
         try:
             with manual_scheme_json.open("r") as file_read:
-                schemes = json.load(file_read)
-                scheme_path = Path(schemes[wallpaper_name]).expanduser()
+                schemes: dict = json.load(file_read)
+
+                wallpaper_name: str = wallpaper_path.name
+
+                # Look for wallpaper name exact match
+                if wallpaper_name in schemes.keys():
+                    scheme_path = Path(schemes[wallpaper_name]).expanduser()
+
+                # If none, look for regex match against path
+                elif match := next((k for k in schemes if re.search(k, str(wallpaper_path))), None):
+                    scheme_path = Path(schemes[match]).expanduser()
+                else:
+                    raise KeyError
+
         except (IOError, json.JSONDecodeError):
-            fallback_to_dynamic("Cannot open manual-scheme.json file.")
+            fallback_to_dynamic("Cannot open manual-scheme.json.")
             return
         except KeyError:
-            fallback_to_dynamic(f"No manual scheme matching {wallpaper_name} found.")
+            fallback_to_dynamic(f"No manual scheme matching {wallpaper_path} found.")
             return
 
         try:

--- a/src/caelestia/utils/scheme.py
+++ b/src/caelestia/utils/scheme.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any
 
 from caelestia.utils.notify import notify
-from caelestia.utils.paths import atomic_dump, manual_scheme_json, scheme_data_dir, scheme_path, wallpaper_path_path
+from caelestia.utils.paths import atomic_dump, scheme_override_json, scheme_data_dir, scheme_path, wallpaper_path_path
 
 
 class Scheme:
@@ -157,12 +157,14 @@ class Scheme:
     def _update_colours(self) -> None:
         if self.name == "dynamic":
             self._update_colours_dynamic()
-        elif self.name == "manual":
-            self._update_colours_manual()
         else:
             self._colours = read_colours_from_file(self.get_colours_path())
 
     def _update_colours_dynamic(self) -> None:
+
+        if (self._update_colours_override()):
+            return
+
         from caelestia.utils.material import get_colours_for_image
 
         try:
@@ -179,26 +181,21 @@ class Scheme:
                 "No wallpaper set. Please set a wallpaper via `caelestia wallpaper` before setting a dynamic scheme."
             )
 
-    def _update_colours_manual(self) -> None:
-        """Look if there is a manual scheme for the current wallpaper.
-
-        Logic:
-            - Open `manual_scheme_json`
-            - Look for exact wallpaper name match
-            - If none, look for regex wallpaper path match
-            - If none, use dynamic coloring.
+    def _update_colours_override(self) -> bool:
+        """Tries to load a custom scheme from the scheme-override.json file.
+        Returns true if the override succeeds, and false otherwise.
         """
 
-        def fallback_to_dynamic(message: str) -> None:
-            """Fallback to dynamic scheme if there is no user scheme for the current wallpaper."""
+        def error_notification(message: str) -> None:
+            """Shows a custom notification to let the user know why the override failed."""
+
             if self.notify:
                 notify(
                     "-u",
                     "normal",
-                    "Cannot set manual scheme",
+                    "No overriding scheme found",
                     message,
                 )
-            self._update_colours_dynamic()
 
         wallpaper_path: Path = Path()
         scheme_path: Path = Path()
@@ -206,18 +203,18 @@ class Scheme:
         try:
             with wallpaper_path_path.open("r") as file_read:
                 wallpaper_path = Path(file_read.read())
-        except (IOError, json.JSONDecodeError):
-            fallback_to_dynamic("Cannot get wallpaper name.")
-            return
+        except (OSError, json.JSONDecodeError):
+            error_notification("Cannot get wallpaper name.")
+            return False
 
         try:
-            with manual_scheme_json.open("r") as file_read:
-                schemes: dict = json.load(file_read)
+            with scheme_override_json.open("r") as file_read:
+                schemes: dict[str, str] = json.load(file_read)
 
                 wallpaper_name: str = wallpaper_path.name
 
                 # Look for wallpaper name exact match
-                if wallpaper_name in schemes.keys():
+                if wallpaper_name in schemes:
                     scheme_path = Path(schemes[wallpaper_name]).expanduser()
 
                 # If none, look for regex match against path
@@ -226,18 +223,20 @@ class Scheme:
                 else:
                     raise KeyError
 
-        except (IOError, json.JSONDecodeError):
-            fallback_to_dynamic("Cannot open manual-scheme.json.")
-            return
+        except (OSError, json.JSONDecodeError):
+            error_notification("Cannot open manual-scheme.json.")
+            return False
         except KeyError:
-            fallback_to_dynamic(f"No manual scheme matching {wallpaper_path} found.")
-            return
+            error_notification(f"No manual scheme matching {wallpaper_path} found.")
+            return False
 
         try:
             self._colours = read_colours_from_file(scheme_path)
         except Exception:
-            fallback_to_dynamic(f"Failed to read colors from {scheme_path}.")
-            return
+            error_notification(f"Failed to read colors from {scheme_path}.")
+            return False
+
+        return True
 
     def __str__(self) -> str:
         return (
@@ -289,7 +288,7 @@ def get_scheme() -> Scheme:
 
 
 def get_scheme_names() -> list[str]:
-    return [*(f.name for f in scheme_data_dir.iterdir() if f.is_dir()), "dynamic", "manual"]
+    return [*(f.name for f in scheme_data_dir.iterdir() if f.is_dir()), "dynamic"]
 
 
 def get_scheme_flavours(name: str | None = None) -> list[str]:
@@ -297,9 +296,6 @@ def get_scheme_flavours(name: str | None = None) -> list[str]:
         name = get_scheme().name
 
     if name == "dynamic":
-        return ["default", "hard"]
-    elif name == "manual":
-        # Shows the same flavors as dynamic as they are only used when falling back on dynamic scheme generation
         return ["default", "hard"]
     else:
         return [f.name for f in (scheme_data_dir / name).iterdir() if f.is_dir()]
@@ -312,8 +308,6 @@ def get_scheme_modes(name: str | None = None, flavour: str | None = None) -> lis
         flavour = flavour or scheme.flavour
 
     if name == "dynamic":
-        return ["light", "dark"]
-    elif name == "manual":
         return ["light", "dark"]
     else:
         return [f.stem for f in (scheme_data_dir / name / flavour).iterdir() if f.is_file()]


### PR DESCRIPTION
This PR adds a new scheme: manual.

# Why

The dynamic scheme works nicely with some wallpapers, and with others I like to use my own scheme. However, if I use a custom scheme, it stays on when I change my wallpaper, which is not ideal either.

Additionally, overwriting the scheme file with a posthook script is not a good option since other scripts watching wallpaper change will use the scheme before it is overwritten. 

# How

The manual scheme checks if the user has a custom scheme file for the current wallpaper at the path `~/.config/caelestia/schemes/<wallpaper_name>.txt`.
If that file exists, then it is used as the theme; otherwise, the dynamic scheme is used.

# Notes

- The user needs to create `~/.config/caelestia/schemes/` to put their custom schemes.
- The <wallpaper_name> also contains the file extension (so the scheme name will end up like `my_wallpaper.png.txt`)
- If the user has two wallpapers with the same name and extension, they will use the same manual scheme, but I don't think that's an issue.
- Manual scheme has the same flavors as dynamic, but doesn't directly use them (they are used when the scheme falls back to dynamic)