### PR TITLE
fix(utils): prevent infinite recursion in Score.score when no primary color found

### DIFF
--- a/src/caelestia/utils/material/score.py
+++ b/src/caelestia/utils/material/score.py
@@ -63,7 +63,13 @@ class Score:
             if primary:
                 break
 
-        return DislikeAnalyzer.fix_if_disliked(primary) if primary else Score.score(colors_to_population, False)
+        if primary:
+            return DislikeAnalyzer.fix_if_disliked(primary)
+
+        if scored_hct:
+            return scored_hct[0]["hct"]
+
+        return DislikeAnalyzer.fix_if_disliked(None)
 
 
 def score(image: str) -> Hct:


### PR DESCRIPTION
When all quantized colors have zero chroma (e.g. grayscale images), the Score.score() method recurses infinitely because primary stays None and the fallback calls itself with the same arguments.

Fix: return the highest-scored color as fallback instead of recursing.