### PR TITLE
feat: video wallpaper support in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The main control script for the Caelestia dotfiles.
 - `glib2` - closing notifications
 - [`cliphist`](https://github.com/sentriz/cliphist) - clipboard history
 - [`fuzzel`](https://codeberg.org/dnkl/fuzzel) - clipboard history/emoji picker
+- [`ffmpegthumbnailer`](https://github.com/dirkvdb/ffmpegthumbnailer) - video wallpaper thumbnails
 
 </details>
 

--- a/src/caelestia/parser.py
+++ b/src/caelestia/parser.py
@@ -124,6 +124,11 @@ def parse_args() -> tuple[argparse.ArgumentParser, argparse.Namespace]:
         action="store_true",
         help="do not automatically change the scheme mode based on wallpaper colour",
     )
+    wallpaper_parser.add_argument(
+        "--update-thumbs",
+        action="store_true",
+        help="generate missing video wallpaper thumbnails",
+    )
 
     # Create parser for resizer opts
     resizer_parser = command_parser.add_parser("resizer", help="window resizer daemon")

--- a/src/caelestia/subcommands/wallpaper.py
+++ b/src/caelestia/subcommands/wallpaper.py
@@ -1,7 +1,7 @@
 import json
 from argparse import Namespace
 
-from caelestia.utils.wallpaper import get_colours_for_wall, get_wallpaper, set_random, set_wallpaper
+from caelestia.utils.wallpaper import get_colours_for_wall, get_wallpaper, set_random, set_wallpaper, update_video_thumbs
 
 
 class Command:
@@ -15,6 +15,8 @@ class Command:
             print(json.dumps(get_colours_for_wall(self.args.print, self.args.no_smart)))
         elif self.args.file:
             set_wallpaper(self.args.file, self.args.no_smart)
+        elif self.args.update_thumbs:
+            update_video_thumbs()
         elif self.args.random:
             set_random(self.args)
         else:

--- a/src/caelestia/utils/material/score.py
+++ b/src/caelestia/utils/material/score.py
@@ -63,7 +63,13 @@ class Score:
             if primary:
                 break
 
-        return DislikeAnalyzer.fix_if_disliked(primary) if primary else Score.score(colors_to_population, False)
+        if primary:
+            return DislikeAnalyzer.fix_if_disliked(primary)
+
+        if scored_hct:
+            return scored_hct[0]["hct"]
+
+        return DislikeAnalyzer.fix_if_disliked(None)
 
 
 def score(image: str) -> Hct:

--- a/src/caelestia/utils/paths.py
+++ b/src/caelestia/utils/paths.py
@@ -34,6 +34,7 @@ scheme_data_dir: Path = cli_data_dir / "schemes"
 scheme_cache_dir: Path = c_cache_dir / "schemes"
 
 wallpapers_dir: Path = Path(os.getenv("CAELESTIA_WALLPAPERS_DIR", pictures_dir / "Wallpapers"))
+videowallpapers_dir: Path = Path(os.getenv("CAELESTIA_VIDEO_WALLPAPERS_DIR", videos_dir / "Wallpapers"))
 wallpaper_path_path: Path = c_state_dir / "wallpaper/path.txt"
 wallpaper_link_path: Path = c_state_dir / "wallpaper/current"
 wallpaper_thumbnail_path: Path = c_state_dir / "wallpaper/thumbnail.jpg"

--- a/src/caelestia/utils/wallpaper.py
+++ b/src/caelestia/utils/wallpaper.py
@@ -109,7 +109,13 @@ def get_colours_for_wall(wall: Path | str, no_smart: bool) -> None:
     scheme = get_scheme()
     cache = wallpapers_cache_dir / compute_hash(wall)
 
-    if wall.suffix.lower() == ".gif":
+    if is_valid_video(wall):
+        thumb_path = wall.parent / ".thumbs" / f"{wall.stem}.jpg"
+        if thumb_path.exists():
+            wall = thumb_path
+        else:
+            wall = extract_video_frame(wall, cache)
+    elif wall.suffix.lower() == ".gif":
         wall = convert_gif(wall)
 
     name = "dynamic"

--- a/src/caelestia/utils/wallpaper.py
+++ b/src/caelestia/utils/wallpaper.py
@@ -24,9 +24,15 @@ from caelestia.utils.paths import (
 from caelestia.utils.scheme import Scheme, get_scheme
 from caelestia.utils.theme import apply_colours
 
+VIDEO_EXTENSIONS = [".mp4", ".webm", ".mkv", ".avi", ".mov", ".gif"]
+
 
 def is_valid_image(path: Path) -> bool:
     return path.is_file() and path.suffix in [".jpg", ".jpeg", ".png", ".webp", ".tif", ".tiff", ".gif"]
+
+
+def is_valid_video(path: Path) -> bool:
+    return path.is_file() and path.suffix in VIDEO_EXTENSIONS
 
 
 def check_wall(wall: Path, filter_size: tuple[int, int], threshold: float) -> bool:
@@ -47,7 +53,7 @@ def get_wallpapers(args: Namespace) -> list[Path]:
     if not directory.is_dir():
         return []
 
-    walls = [f for f in directory.rglob("*") if is_valid_image(f)]
+    walls = [f for f in directory.rglob("*") if is_valid_image(f) or is_valid_video(f)]
 
     if args.no_filter:
         return walls
@@ -55,7 +61,7 @@ def get_wallpapers(args: Namespace) -> list[Path]:
     monitors = cast(list[dict[str, int]], message("monitors"))
     filter_size = min(m["width"] for m in monitors), min(m["height"] for m in monitors)
 
-    return [f for f in walls if check_wall(f, filter_size, args.threshold)]
+    return [f for f in walls if is_valid_video(f) or check_wall(f, filter_size, args.threshold)]
 
 
 def get_thumb(wall: Path, cache: Path) -> Path:
@@ -129,6 +135,18 @@ def get_colours_for_wall(wall: Path | str, no_smart: bool) -> None:
     }
 
 
+def extract_video_frame(wall: Path, cache: Path) -> Path:
+    output_path = cache / "first_frame.png"
+    if not output_path.exists():
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        subprocess.run(
+            ["ffmpeg", "-i", str(wall), "-vframes", "1", "-q:v", "2", str(output_path)],
+            capture_output=True,
+            check=False
+        )
+    return output_path
+
+
 def convert_gif(wall: Path) -> Path:
     cache = wallpapers_cache_dir / compute_hash(wall)
     output_path = cache / "first_frame.png"
@@ -148,14 +166,17 @@ def convert_gif(wall: Path) -> Path:
 
 
 def set_wallpaper(wall: Path, no_smart: bool) -> None:
-    # Make path absolute
     wall = Path(wall).resolve()
 
-    if not is_valid_image(wall):
-        raise ValueError(f'"{wall}" is not a valid image')
+    if not is_valid_image(wall) and not is_valid_video(wall):
+        raise ValueError(f'"{wall}" is not a valid image or video')
 
-    # Use gif's 1st frame for thumb only
-    wall_cache = convert_gif(wall) if wall.suffix.lower() == ".gif" else wall
+    if is_valid_video(wall):
+        wall_cache = extract_video_frame(wall, wallpapers_cache_dir / compute_hash(wall))
+    elif wall.suffix.lower() == ".gif":
+        wall_cache = convert_gif(wall)
+    else:
+        wall_cache = wall
 
     # Update files
     wallpaper_path_path.parent.mkdir(parents=True, exist_ok=True)
@@ -171,6 +192,14 @@ def set_wallpaper(wall: Path, no_smart: bool) -> None:
     wallpaper_thumbnail_path.parent.mkdir(parents=True, exist_ok=True)
     wallpaper_thumbnail_path.unlink(missing_ok=True)
     wallpaper_thumbnail_path.symlink_to(thumb)
+
+    # Copy full-res frame to video dir for QML carousel access
+    if is_valid_video(wall):
+        thumbs_dir = wall.parent / ".thumbs"
+        thumbs_dir.mkdir(parents=True, exist_ok=True)
+        dest = thumbs_dir / f"{wall.stem}.jpg"
+        with Image.open(wall_cache) as img:
+            img.convert("RGB").save(dest, "JPEG", quality=90)
 
     scheme = get_scheme()
 

--- a/src/caelestia/utils/wallpaper.py
+++ b/src/caelestia/utils/wallpaper.py
@@ -111,12 +111,23 @@ def video_thumb_path(wall: Path) -> Path:
     return wall.parent / ".thumbs" / f"{wall.stem}.jpg"
 
 
+def generate_video_thumb(video: Path, dest: Path) -> None:
+    if shutil.which("ffmpegthumbnailer") is None:
+        return
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["ffmpegthumbnailer", "-i", str(video), "-o", str(dest), "-s", "512", "-q", "8"],
+        capture_output=True,
+        check=False,
+    )
+
+
 def colour_source(wall: Path) -> Path:
     if is_valid_video(wall):
         thumb_path = video_thumb_path(wall)
-        if thumb_path.exists():
-            return thumb_path
-        return extract_video_frame(wall, wallpapers_cache_dir / compute_hash(wall))
+        if not thumb_path.exists():
+            generate_video_thumb(wall, thumb_path)
+        return thumb_path
     if wall.suffix.lower() == ".gif":
         return convert_gif(wall)
     return wall
@@ -147,18 +158,6 @@ def get_colours_for_wall(wall: Path | str, no_smart: bool) -> dict:
         "variant": scheme.variant,
         "colours": get_colours_for_image(get_thumb(wall, cache), scheme),
     }
-
-
-def extract_video_frame(wall: Path, cache: Path) -> Path:
-    output_path = cache / "first_frame.png"
-    if not output_path.exists():
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        subprocess.run(
-            ["ffmpeg", "-i", str(wall), "-vframes", "1", "-q:v", "2", str(output_path)],
-            capture_output=True,
-            check=False
-        )
-    return output_path
 
 
 def convert_gif(wall: Path) -> Path:
@@ -201,10 +200,6 @@ def set_wallpaper(wall: Path, no_smart: bool) -> None:
     wallpaper_thumbnail_path.parent.mkdir(parents=True, exist_ok=True)
     wallpaper_thumbnail_path.unlink(missing_ok=True)
     wallpaper_thumbnail_path.symlink_to(thumb)
-
-    thumb_path = video_thumb_path(wall)
-    if is_valid_video(wall) and not thumb_path.exists():
-        generate_video_thumb(wall, thumb_path)
 
     scheme = get_scheme()
 

--- a/src/caelestia/utils/wallpaper.py
+++ b/src/caelestia/utils/wallpaper.py
@@ -1,6 +1,7 @@
 import json
 import os
 import random
+import shutil
 import subprocess
 from argparse import Namespace
 from pathlib import Path
@@ -202,11 +203,7 @@ def set_wallpaper(wall: Path, no_smart: bool) -> None:
 
     # Copy full-res frame to video dir for QML carousel access
     if is_valid_video(wall):
-        thumbs_dir = wall.parent / ".thumbs"
-        thumbs_dir.mkdir(parents=True, exist_ok=True)
-        dest = thumbs_dir / f"{wall.stem}.jpg"
-        with Image.open(wall_cache) as img:
-            img.convert("RGB").save(dest, "JPEG", quality=90)
+        generate_video_thumb(wall, wall.parent / ".thumbs" / f"{wall.stem}.jpg")
 
     scheme = get_scheme()
 
@@ -240,21 +237,26 @@ def set_wallpaper(wall: Path, no_smart: bool) -> None:
         )
 
 
+def generate_video_thumb(video: Path, dest: Path) -> None:
+    if shutil.which("ffmpegthumbnailer") is None:
+        return
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["ffmpegthumbnailer", "-i", str(video), "-o", str(dest), "-t", "0", "-q", "8", "-s", "0"],
+        capture_output=True,
+        check=False,
+    )
+
+
 def update_video_thumbs() -> None:
     if not videowallpapers_dir.is_dir():
         return
     for f in videowallpapers_dir.iterdir():
         if not is_valid_video(f):
             continue
-        thumbs_dir = f.parent / ".thumbs"
-        dest = thumbs_dir / f"{f.stem}.jpg"
-        if dest.exists():
-            continue
-        thumbs_dir.mkdir(parents=True, exist_ok=True)
-        cache = wallpapers_cache_dir / compute_hash(f)
-        frame = extract_video_frame(f, cache)
-        with Image.open(frame) as img:
-            img.convert("RGB").save(dest, "JPEG", quality=90)
+        dest = f.parent / ".thumbs" / f"{f.stem}.jpg"
+        if not dest.exists():
+            generate_video_thumb(f, dest)
 
 
 def set_random(args: Namespace) -> None:

--- a/src/caelestia/utils/wallpaper.py
+++ b/src/caelestia/utils/wallpaper.py
@@ -240,6 +240,23 @@ def set_wallpaper(wall: Path, no_smart: bool) -> None:
         )
 
 
+def update_video_thumbs() -> None:
+    if not videowallpapers_dir.is_dir():
+        return
+    for f in videowallpapers_dir.iterdir():
+        if not is_valid_video(f):
+            continue
+        thumbs_dir = f.parent / ".thumbs"
+        dest = thumbs_dir / f"{f.stem}.jpg"
+        if dest.exists():
+            continue
+        thumbs_dir.mkdir(parents=True, exist_ok=True)
+        cache = wallpapers_cache_dir / compute_hash(f)
+        frame = extract_video_frame(f, cache)
+        with Image.open(frame) as img:
+            img.convert("RGB").save(dest, "JPEG", quality=90)
+
+
 def set_random(args: Namespace) -> None:
     wallpapers = get_wallpapers(args)
 

--- a/src/caelestia/utils/wallpaper.py
+++ b/src/caelestia/utils/wallpaper.py
@@ -16,6 +16,7 @@ from caelestia.utils.material import get_colours_for_image
 from caelestia.utils.paths import (
     compute_hash,
     get_config,
+    videowallpapers_dir,
     wallpaper_link_path,
     wallpaper_path_path,
     wallpaper_thumbnail_path,
@@ -241,6 +242,11 @@ def set_wallpaper(wall: Path, no_smart: bool) -> None:
 
 def set_random(args: Namespace) -> None:
     wallpapers = get_wallpapers(args)
+
+    if videowallpapers_dir.is_dir():
+        for f in videowallpapers_dir.iterdir():
+            if is_valid_video(f):
+                wallpapers.append(f)
 
     if not wallpapers:
         raise ValueError("No valid wallpapers found")

--- a/src/caelestia/utils/wallpaper.py
+++ b/src/caelestia/utils/wallpaper.py
@@ -107,20 +107,25 @@ def get_smart_opts(wall: Path, cache: Path) -> dict:
     return opts
 
 
-def get_colours_for_wall(wall: Path | str, no_smart: bool) -> None:
-    wall = Path(wall)
+def video_thumb_path(wall: Path) -> Path:
+    return wall.parent / ".thumbs" / f"{wall.stem}.jpg"
+
+
+def colour_source(wall: Path) -> Path:
+    if is_valid_video(wall):
+        thumb_path = video_thumb_path(wall)
+        if thumb_path.exists():
+            return thumb_path
+        return extract_video_frame(wall, wallpapers_cache_dir / compute_hash(wall))
+    if wall.suffix.lower() == ".gif":
+        return convert_gif(wall)
+    return wall
+
+
+def get_colours_for_wall(wall: Path | str, no_smart: bool) -> dict:
+    wall = colour_source(Path(wall))
     scheme = get_scheme()
     cache = wallpapers_cache_dir / compute_hash(wall)
-
-    if is_valid_video(wall):
-        thumb_path = wall.parent / ".thumbs" / f"{wall.stem}.jpg"
-        if thumb_path.exists():
-            wall = thumb_path
-        else:
-            wall = extract_video_frame(wall, cache)
-    elif wall.suffix.lower() == ".gif":
-        wall = convert_gif(wall)
-
     name = "dynamic"
 
     if not no_smart:
@@ -180,12 +185,7 @@ def set_wallpaper(wall: Path, no_smart: bool) -> None:
     if not is_valid_image(wall) and not is_valid_video(wall):
         raise ValueError(f'"{wall}" is not a valid image or video')
 
-    if is_valid_video(wall):
-        wall_cache = extract_video_frame(wall, wallpapers_cache_dir / compute_hash(wall))
-    elif wall.suffix.lower() == ".gif":
-        wall_cache = convert_gif(wall)
-    else:
-        wall_cache = wall
+    wall_cache = colour_source(wall)
 
     # Update files
     wallpaper_path_path.parent.mkdir(parents=True, exist_ok=True)
@@ -202,9 +202,9 @@ def set_wallpaper(wall: Path, no_smart: bool) -> None:
     wallpaper_thumbnail_path.unlink(missing_ok=True)
     wallpaper_thumbnail_path.symlink_to(thumb)
 
-    # Copy full-res frame to video dir for QML carousel access
-    if is_valid_video(wall):
-        generate_video_thumb(wall, wall.parent / ".thumbs" / f"{wall.stem}.jpg")
+    thumb_path = video_thumb_path(wall)
+    if is_valid_video(wall) and not thumb_path.exists():
+        generate_video_thumb(wall, thumb_path)
 
     scheme = get_scheme()
 
@@ -243,7 +243,7 @@ def generate_video_thumb(video: Path, dest: Path) -> None:
         return
     dest.parent.mkdir(parents=True, exist_ok=True)
     subprocess.run(
-        ["ffmpegthumbnailer", "-i", str(video), "-o", str(dest), "-s", "512", "-q", "5"],
+        ["ffmpegthumbnailer", "-i", str(video), "-o", str(dest), "-s", "512", "-q", "8"],
         capture_output=True,
         check=False,
     )

--- a/src/caelestia/utils/wallpaper.py
+++ b/src/caelestia/utils/wallpaper.py
@@ -242,7 +242,7 @@ def generate_video_thumb(video: Path, dest: Path) -> None:
         return
     dest.parent.mkdir(parents=True, exist_ok=True)
     subprocess.run(
-        ["ffmpegthumbnailer", "-i", str(video), "-o", str(dest), "-t", "0", "-q", "8", "-s", "0"],
+        ["ffmpegthumbnailer", "-i", str(video), "-o", str(dest), "-s", "0", "-q", "10"],
         capture_output=True,
         check=False,
     )

--- a/src/caelestia/utils/wallpaper.py
+++ b/src/caelestia/utils/wallpaper.py
@@ -4,6 +4,7 @@ import random
 import shutil
 import subprocess
 from argparse import Namespace
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import cast
 
@@ -242,7 +243,7 @@ def generate_video_thumb(video: Path, dest: Path) -> None:
         return
     dest.parent.mkdir(parents=True, exist_ok=True)
     subprocess.run(
-        ["ffmpegthumbnailer", "-i", str(video), "-o", str(dest), "-s", "0", "-q", "10"],
+        ["ffmpegthumbnailer", "-i", str(video), "-o", str(dest), "-s", "512", "-q", "5"],
         capture_output=True,
         check=False,
     )
@@ -251,12 +252,18 @@ def generate_video_thumb(video: Path, dest: Path) -> None:
 def update_video_thumbs() -> None:
     if not videowallpapers_dir.is_dir():
         return
+    missing = []
     for f in videowallpapers_dir.iterdir():
         if not is_valid_video(f):
             continue
         dest = f.parent / ".thumbs" / f"{f.stem}.jpg"
         if not dest.exists():
-            generate_video_thumb(f, dest)
+            missing.append((f, dest))
+    if not missing:
+        return
+    with ThreadPoolExecutor() as pool:
+        for f, dest in missing:
+            pool.submit(generate_video_thumb, f, dest)
 
 
 def set_random(args: Namespace) -> None:


### PR DESCRIPTION
- Add VIDEO_EXTENSIONS, is_valid_video helpers
- extract_video_frame: extract first frame via ffmpeg for color scheme
- Support video files in get_wallpapers and set_wallpaper
- Copy full-res frame to .thumbs/ for QML carousel thumbnails

Edit: this PR is a CLI part of https://github.com/caelestia-dots/shell/pull/1710

Edit 2: This PR also includes the fix from https://github.com/caelestia-dots/cli/pull/135

Edit 3:
- Random picks from ~/Videos/Wallpapers/ too

Edit 4:
- ffmpegthumbnailer instead of Python frame extraction; quality 8, 512px on the longer side
*should be added as a dependency in PKGBUILD