### PR TITLE
feat(scheme): add custom user colour schemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,156 @@ Custom user templates can be defined in `~/.config/caelestia/templates/`.
 
 Output files are written to `~/.local/state/caelestia/theme/`. You can symlink them to your desired locations.
 
+### User colour schemes
+
+Custom user colour schemes can be added in `~/.config/caelestia/schemes/`.
+
+#### Directory structure
+
+`~/.config/caelestia/schemes/<name>/<flavour>/<mode>.txt`
+
+- `<name>` is the name of your scheme (e.g. `mytheme`).
+- `<flavour>` is the flavour (e.g. `default`, `mocha`).
+- `<mode>` is the mode: `dark` or `light`.
+
+Once created, these schemes will then be available in the launcher `>scheme`, in `caelestia scheme list`, and in shell autocompletions.
+
+> [!NOTE]
+> User scheme names should not be the same with bundled schemes (for example, `catppuccin`, `dracula`). If they are the same user schemes are ignored.
+
+#### Examples
+
+Each file is a plain text list of `key value` pairs (no `#` prefixes).
+- `background 0a0f0f`
+- `primary 9bd0cc`
+
+<details><summary>Example colour scheme content</summary>
+
+```text
+background 0a0f0f
+onBackground dce8e6
+surface 0a0f0f
+surfaceDim 0a0f0f
+surfaceBright 242e2d
+surfaceContainerLowest 000000
+surfaceContainerLow 0e1514
+surfaceContainer 131b1a
+surfaceContainerHigh 192120
+surfaceContainerHighest 1d2827
+onSurface dce8e6
+surfaceVariant 1d2827
+onSurfaceVariant a2adac
+outline 6d7876
+outlineVariant 3f4a49
+inverseSurface f6faf9
+inverseOnSurface 515655
+shadow 000000
+scrim 000000
+surfaceTint 9bd0cc
+primary 9bd0cc
+primaryDim 8ec2bf
+onPrimary 0d4845
+primaryContainer 255b58
+onPrimaryContainer b8ede9
+inversePrimary 336764
+primaryFixed b7ede9
+primaryFixedDim a9deda
+onPrimaryFixed 0c4744
+onPrimaryFixedVariant 306461
+secondary b0ccc9
+secondaryDim a3bebc
+onSecondary 2c4543
+secondaryContainer 27403e
+onSecondaryContainer a9c5c2
+secondaryFixed cce8e5
+secondaryFixedDim bedad7
+onSecondaryFixed 2b4442
+onSecondaryFixedVariant 47605e
+tertiary d5efff
+tertiaryDim b6e3fe
+onTertiary 2e5c72
+tertiaryContainer b6e3fe
+onTertiaryContainer 255369
+tertiaryFixed b6e3fe
+tertiaryFixedDim a8d5ef
+onTertiaryFixed 0b4156
+onTertiaryFixedVariant 2f5d73
+error fa746f
+errorDim c54d4a
+onError 490006
+errorContainer 871f21
+onErrorContainer ff9993
+primaryPaletteKeyColor 4c807d
+secondaryPaletteKeyColor 627c7a
+tertiaryPaletteKeyColor 517d94
+neutralPaletteKeyColor 737877
+neutralVariantPaletteKeyColor 6e7978
+errorPaletteKeyColor c84f4c
+primary_paletteKeyColor 4c807d
+secondary_paletteKeyColor 627c7a
+tertiary_paletteKeyColor 517d94
+neutral_paletteKeyColor 737877
+neutral_variant_paletteKeyColor 6e7978
+term0 343434
+term1 769e00
+term2 56e2c0
+term3 81fcce
+term4 76b6b3
+term5 7aaee9
+term6 83d8c9
+term7 cddcd3
+term8 9aa59e
+term9 85b900
+term10 41f7d0
+term11 cdffe9
+term12 a3c8c3
+term13 a2c0f7
+term14 8bedd9
+term15 ffffff
+rosewater f1f3e5
+flamingo e3e4c5
+pink bae2ff
+mauve 60cfe8
+red 8ab5ff
+maroon abbef0
+peach a9daac
+yellow d3fae8
+green 8df1df
+teal 9feee7
+sky 93eae9
+sapphire 70d7db
+blue 57cdda
+lavender 86d9e7
+klink 00969e
+klinkSelection 00969e
+kvisited 008ca9
+kvisitedSelection 008ca9
+knegative 838f00
+knegativeSelection 838f00
+kneutral 34c359
+kneutralSelection 34c359
+kpositive 00beab
+kpositiveSelection 00beab
+text dce8e6
+subtext1 a2adac
+subtext0 6d7876
+overlay2 5f6967
+overlay1 505958
+overlay0 434b4a
+surface2 353d3c
+surface1 282e2e
+surface0 191f1e
+base 0a0f0f
+mantle 0a0f0f
+crust 090e0e
+success B5CCBA
+onSuccess 213528
+successContainer 374B3E
+onSuccessContainer D1E9D6
+```
+
+</details>
+
 ## Configuring
 
 All configuration options are in `~/.config/caelestia/cli.json`.

--- a/README.md
+++ b/README.md
@@ -194,8 +194,8 @@ Custom user colour schemes can be added in `~/.config/caelestia/schemes/`.
 
 Once created, these schemes will then be available in the launcher `>scheme`, in `caelestia scheme list`, and in shell autocompletions.
 
-> [!NOTE]
-> User scheme names should not be the same with bundled schemes (for example, `catppuccin`, `dracula`). If they are the same user schemes are ignored.
+> [!TIP]
+> User scheme will replace any existing one with the same name. You can also extend existing scheme by creating new flavours or modes (for example new flavour for catpuccin, `~/.config/caelestia/schemes/catppuccin/newflavour/dark.txt`).
 
 #### Examples
 

--- a/src/caelestia/subcommands/scheme.py
+++ b/src/caelestia/subcommands/scheme.py
@@ -109,12 +109,14 @@ class List:
                         }
                     )
                     modes = get_scheme_modes(scheme, flavour)
+                    if not modes:
+                        continue
                     if s.mode not in modes:
                         s._mode = modes[0]
                     try:
                         s._update_colours()
                         schemes[scheme][flavour] = s.colours
-                    except ValueError:
+                    except (ValueError, KeyError, OSError):
                         pass
 
             print(json.dumps(schemes))

--- a/src/caelestia/utils/material/generator.py
+++ b/src/caelestia/utils/material/generator.py
@@ -20,6 +20,7 @@ from typing import Protocol, Any
 class SchemeConstructor(Protocol):
     def __call__(self, source_color_hct: Any, is_dark: bool, contrast_level: float) -> "DynamicScheme": ...
 
+
 try:
     from materialyoucolor.dynamiccolor.dynamic_scheme import DynamicScheme
 except ImportError:

--- a/src/caelestia/utils/material/generator.py
+++ b/src/caelestia/utils/material/generator.py
@@ -20,7 +20,6 @@ from typing import Protocol, Any
 class SchemeConstructor(Protocol):
     def __call__(self, source_color_hct: Any, is_dark: bool, contrast_level: float) -> "DynamicScheme": ...
 
-
 try:
     from materialyoucolor.dynamiccolor.dynamic_scheme import DynamicScheme
 except ImportError:

--- a/src/caelestia/utils/paths.py
+++ b/src/caelestia/utils/paths.py
@@ -31,6 +31,7 @@ dots_state_path: Path = c_state_dir / "dots-state.json"
 
 scheme_path: Path = c_state_dir / "scheme.json"
 scheme_data_dir: Path = cli_data_dir / "schemes"
+user_scheme_data_dir: Path = c_config_dir / "schemes"
 scheme_cache_dir: Path = c_cache_dir / "schemes"
 
 wallpapers_dir: Path = Path(os.getenv("CAELESTIA_WALLPAPERS_DIR", pictures_dir / "Wallpapers"))

--- a/src/caelestia/utils/scheme.py
+++ b/src/caelestia/utils/scheme.py
@@ -4,7 +4,14 @@ from pathlib import Path
 from typing import Any
 
 from caelestia.utils.notify import notify
-from caelestia.utils.paths import atomic_dump, scheme_data_dir, scheme_path
+from caelestia.utils.paths import atomic_dump, scheme_data_dir, scheme_path, user_scheme_data_dir
+
+
+def _scheme_root(name: str) -> Path:
+    bundled = scheme_data_dir / name
+    if bundled.is_dir():
+        return bundled
+    return user_scheme_data_dir / name
 
 
 class Scheme:
@@ -118,7 +125,7 @@ class Scheme:
         return self._colours
 
     def get_colours_path(self) -> Path:
-        return (scheme_data_dir / self.name / self.flavour / self.mode).with_suffix(".txt")
+        return (_scheme_root(self.name) / self.flavour / self.mode).with_suffix(".txt")
 
     def save(self) -> None:
         scheme_path.parent.mkdir(parents=True, exist_ok=True)
@@ -223,16 +230,36 @@ def get_scheme() -> Scheme:
 
 
 def get_scheme_names() -> list[str]:
-    return [*(f.name for f in scheme_data_dir.iterdir() if f.is_dir()), "dynamic"]
+    try:
+        bundled = [f.name for f in scheme_data_dir.iterdir() if f.is_dir()]
+    except OSError:
+        bundled = []
+
+    user = []
+    if user_scheme_data_dir.is_dir():
+        try:
+            user = [
+                f.name
+                for f in user_scheme_data_dir.iterdir()
+                if f.is_dir() and f.name not in bundled and f.name != "dynamic"
+            ]
+        except OSError:
+            pass
+
+    return [*bundled, *user, "dynamic"]
 
 
 def get_scheme_flavours(name: str | None = None) -> list[str]:
     if name is None:
         name = get_scheme().name
 
-    return (
-        ["default", "hard"] if name == "dynamic" else [f.name for f in (scheme_data_dir / name).iterdir() if f.is_dir()]
-    )
+    if name == "dynamic":
+        return ["default", "hard"]
+
+    try:
+        return [f.name for f in _scheme_root(name).iterdir() if f.is_dir()]
+    except OSError:
+        return []
 
 
 def get_scheme_modes(name: str | None = None, flavour: str | None = None) -> list[str]:
@@ -243,5 +270,8 @@ def get_scheme_modes(name: str | None = None, flavour: str | None = None) -> lis
 
     if name == "dynamic":
         return ["light", "dark"]
-    else:
-        return [f.stem for f in (scheme_data_dir / name / flavour).iterdir() if f.is_file()]
+
+    try:
+        return [f.stem for f in (_scheme_root(name) / flavour).iterdir() if f.is_file()]
+    except OSError:
+        return []

--- a/src/caelestia/utils/scheme.py
+++ b/src/caelestia/utils/scheme.py
@@ -7,11 +7,16 @@ from caelestia.utils.notify import notify
 from caelestia.utils.paths import atomic_dump, scheme_data_dir, scheme_path, user_scheme_data_dir
 
 
-def _scheme_root(name: str) -> Path:
-    bundled = scheme_data_dir / name
-    if bundled.is_dir():
-        return bundled
-    return user_scheme_data_dir / name
+def _scheme_dirs(name: str) -> list[Path]:
+    return [user_scheme_data_dir / name, scheme_data_dir / name]
+
+
+def _resolve_scheme_file(name: str, flavour: str, mode: str) -> Path:
+    for root in _scheme_dirs(name):
+        candidate = root / flavour / f"{mode}.txt"
+        if candidate.is_file():
+            return candidate
+    return _scheme_dirs(name)[-1] / flavour / f"{mode}.txt"
 
 
 class Scheme:
@@ -125,7 +130,7 @@ class Scheme:
         return self._colours
 
     def get_colours_path(self) -> Path:
-        return (_scheme_root(self.name) / self.flavour / self.mode).with_suffix(".txt")
+        return _resolve_scheme_file(self.name, self.flavour, self.mode)
 
     def save(self) -> None:
         scheme_path.parent.mkdir(parents=True, exist_ok=True)
@@ -231,7 +236,7 @@ def get_scheme() -> Scheme:
 
 def get_scheme_names() -> list[str]:
     try:
-        bundled = [f.name for f in scheme_data_dir.iterdir() if f.is_dir()]
+        bundled = [f.name for f in scheme_data_dir.iterdir() if f.is_dir() and get_scheme_flavours(f.name)]
     except OSError:
         bundled = []
 
@@ -241,7 +246,7 @@ def get_scheme_names() -> list[str]:
             user = [
                 f.name
                 for f in user_scheme_data_dir.iterdir()
-                if f.is_dir() and f.name not in bundled and f.name != "dynamic"
+                if f.is_dir() and f.name not in bundled and f.name != "dynamic" and get_scheme_flavours(f.name)
             ]
         except OSError:
             pass
@@ -256,10 +261,17 @@ def get_scheme_flavours(name: str | None = None) -> list[str]:
     if name == "dynamic":
         return ["default", "hard"]
 
-    try:
-        return [f.name for f in _scheme_root(name).iterdir() if f.is_dir()]
-    except OSError:
-        return []
+    flavours: list[str] = []
+    seen: set[str] = set()
+    for root in _scheme_dirs(name):
+        try:
+            for f in root.iterdir():
+                if f.is_dir() and f.name not in seen and any(p.is_file() and p.suffix == ".txt" for p in f.iterdir()):
+                    seen.add(f.name)
+                    flavours.append(f.name)
+        except OSError:
+            pass
+    return flavours
 
 
 def get_scheme_modes(name: str | None = None, flavour: str | None = None) -> list[str]:
@@ -271,7 +283,14 @@ def get_scheme_modes(name: str | None = None, flavour: str | None = None) -> lis
     if name == "dynamic":
         return ["light", "dark"]
 
-    try:
-        return [f.stem for f in (_scheme_root(name) / flavour).iterdir() if f.is_file()]
-    except OSError:
-        return []
+    modes: list[str] = []
+    seen: set[str] = set()
+    for root in _scheme_dirs(name):
+        try:
+            for f in (root / flavour).iterdir():
+                if f.is_file() and f.suffix == ".txt" and f.stem not in seen:
+                    seen.add(f.stem)
+                    modes.append(f.stem)
+        except OSError:
+            pass
+    return modes


### PR DESCRIPTION
Custom user colour schemes can be added in `~/.config/caelestia/schemes/`.

The directory structure is like this:
`~/.config/caelestia/schemes/<name>/<flavour>/<mode>.txt`
-  `<name>` is the name of your scheme (e.g. mytheme).
-  `<flavour>` is the flavour (e.g. default, mocha).
-  `<mode>` is the mode: dark or light.

~~Btw if a user scheme has the same name as the bundled one, the bundled one wins, and the user's one is ignored.~~
