### PR TITLE
fix(utils): decode hypr socket response after joining all chunks

### DIFF
--- a/src/caelestia/utils/hypr.py
+++ b/src/caelestia/utils/hypr.py
@@ -18,12 +18,13 @@ def message(msg: str, is_json: bool = True) -> str | dict[str, Any]:
             msg = f"j/{msg}"
         sock.send(msg.encode())
 
-        resp = sock.recv(8192).decode()
+        chunks = []
         while True:
-            new_resp = sock.recv(8192)
-            if not new_resp:
+            chunk = sock.recv(8192)
+            if not chunk:
                 break
-            resp += new_resp.decode()
+            chunks.append(chunk)
+        resp = b"".join(chunks).decode()
 
         return json.loads(resp) if is_json else resp
 


### PR DESCRIPTION
My SUPER+M / SUPER+D toggle shortcuts stopped working intermittently, so I looked into the cause.

It turns out message() in hypr.py decodes each 8192-byte chunk from the socket as soon as it arrives, rather than waiting for the full response. Once the response exceeds 8192 bytes (which happens with enough windows open), the chunk boundary can fall in the middle of a multi-byte character in a window title (Korean, in my case), causing .decode() to raise an error before the command runs. I am not entirely certain why that specific boundary triggers it, but this matches what I observed.

The fix collects all chunks first and decodes once at the end, rather than decoding chunk by chunk.

I tested this by opening several windows and repeatedly triggering the toggle shortcut. It worked consistently after the fix, and I did not encounter any other issues.