### PR TITLE
feat(record): add capture and audio modes, and an explicit stop

### DIFF
--- a/completions/caelestia.fish
+++ b/completions/caelestia.fish
@@ -105,8 +105,12 @@ complete -c caelestia -n "$seen screenshot" -s 'r' -l 'region' -d 'Capture regio
 complete -c caelestia -n "$seen screenshot" -s 'f' -l 'freeze' -d 'Freeze while selecting region'
 
 # Record
+complete -c caelestia -n "$seen record" -s 'm' -l 'mode' -d 'What to record' -r -a 'fullscreen region window'
+complete -c caelestia -n "$seen record" -s 'a' -l 'audio' -d 'What to record audio from' -r -a 'none system mic combined'
 complete -c caelestia -n "$seen record" -s 'r' -l 'region' -d 'Capture region'
 complete -c caelestia -n "$seen record" -s 's' -l 'sound' -d 'Capture sound'
+complete -c caelestia -n "$seen record" -s 'p' -l 'pause' -d 'Pause/resume the recording'
+complete -c caelestia -n "$seen record" -l 'stop' -d 'Stop the recording instead of toggling'
 complete -c caelestia -n "$seen record" -s 'c' -l 'clipboard' -d 'Copy recording path to clipboard'
 
 # Clipboard

--- a/src/caelestia/parser.py
+++ b/src/caelestia/parser.py
@@ -85,9 +85,24 @@ def parse_args() -> tuple[argparse.ArgumentParser, argparse.Namespace]:
     # Create parser for record opts
     record_parser = command_parser.add_parser("record", help="start a screen recording")
     record_parser.set_defaults(cls=record.Command)
+    record_parser.add_argument(
+        "-m",
+        "--mode",
+        choices=["fullscreen", "region", "window"],
+        default="fullscreen",
+        help="what to record (default: fullscreen)",
+    )
+    record_parser.add_argument(
+        "-a",
+        "--audio",
+        choices=["none", "system", "mic", "combined"],
+        default="none",
+        help="what to record audio from (default: none)",
+    )
     record_parser.add_argument("-r", "--region", nargs="?", const="slurp", help="record a region")
     record_parser.add_argument("-s", "--sound", action="store_true", help="record audio")
     record_parser.add_argument("-p", "--pause", action="store_true", help="pause/resume the recording")
+    record_parser.add_argument("--stop", action="store_true", help="stop the recording instead of toggling")
     record_parser.add_argument("-c", "--clipboard", action="store_true", help="copy recording path to clipboard")
 
     # Create parser for clipboard opts

--- a/src/caelestia/subcommands/record.py
+++ b/src/caelestia/subcommands/record.py
@@ -12,6 +12,13 @@ from caelestia.utils.paths import get_config, recording_notif_path, recording_pa
 
 RECORDER = "gpu-screen-recorder"
 
+# gpu-screen-recorder resolves these to whatever the current PipeWire defaults are
+AUDIO_DEVICES = {
+    "mic": "default_input",
+    "system": "default_output",
+    "combined": "default_output|default_input",
+}
+
 
 class Command:
     args: Namespace
@@ -22,6 +29,9 @@ class Command:
     def run(self) -> None:
         if self.args.pause:
             subprocess.run(["pkill", "-USR2", "-f", RECORDER], stdout=subprocess.DEVNULL)
+        elif self.args.stop:
+            if self.proc_running():
+                self.stop()
         elif self.proc_running():
             self.stop()
         else:
@@ -33,36 +43,59 @@ class Command:
     def intersects(self, a: tuple[int, int, int, int], b: tuple[int, int, int, int]) -> bool:
         return a[0] < b[0] + b[2] and a[0] + a[2] > b[0] and a[1] < b[1] + b[3] and a[1] + a[3] > b[1]
 
+    def slurp(self, choices: str | None = None) -> str | None:
+        # Returns None when the user cancels, which is not an error
+        proc = subprocess.run(["slurp", "-f", "%wx%h+%x+%y"], input=choices, capture_output=True, text=True)
+        return proc.stdout.strip() if proc.returncode == 0 else None
+
+    # Feeding slurp the window rects turns a freehand drag into a click-to-pick
+    def select_window(self) -> str | None:
+        windows = [c for c in hypr.message("clients") if c["mapped"] and not c["hidden"]]
+        if not windows:
+            raise ValueError("No windows to record")
+        return self.slurp("\n".join(f"{c['at'][0]},{c['at'][1]} {c['size'][0]}x{c['size'][1]}" for c in windows))
+
+    # Recording below the panel's rate wastes frames, above it gains nothing, so
+    # match the fastest monitor the region covers
+    def region_args(self, region: str) -> list[str]:
+        m = re.match(r"(\d+)x(\d+)\+(-?\d+)\+(-?\d+)", region)
+        if not m:
+            raise ValueError(f"Invalid region: {region}")
+
+        w, h, x, y = map(int, m.groups())
+        r = x, y, w, h
+        max_rr = 0
+        for monitor in hypr.message("monitors"):
+            if self.intersects((monitor["x"], monitor["y"], monitor["width"], monitor["height"]), r):
+                max_rr = max(max_rr, round(monitor["refreshRate"]))
+
+        return ["region", "-region", region, "-f", str(max_rr)]
+
     def start(self) -> None:
         args = ["-w"]
 
-        monitors = hypr.message("monitors")
-        if self.args.region:
-            if self.args.region == "slurp":
-                region = subprocess.check_output(["slurp", "-f", "%wx%h+%x+%y"], text=True)
-            else:
+        if self.args.mode == "window":
+            region = self.select_window()
+            if region is None:
+                return
+            args += self.region_args(region)
+        elif self.args.mode == "region" or self.args.region:
+            if self.args.region and self.args.region != "slurp":
                 region = self.args.region.strip()
-            args += ["region", "-region", region]
-
-            m = re.match(r"(\d+)x(\d+)\+(-?\d+)\+(-?\d+)", region)
-            if not m:
-                raise ValueError(f"Invalid region: {region}")
-
-            w, h, x, y = map(int, m.groups())
-            r = x, y, w, h
-            max_rr = 0
-            for monitor in monitors:
-                if self.intersects((monitor["x"], monitor["y"], monitor["width"], monitor["height"]), r):
-                    rr = round(monitor["refreshRate"])
-                    max_rr = max(max_rr, rr)
-            args += ["-f", str(max_rr)]
+            else:
+                region = self.slurp()
+                if region is None:
+                    return
+            args += self.region_args(region)
         else:
+            monitors = hypr.message("monitors")
             focused_monitor = next(monitor for monitor in monitors if monitor["focused"])
             if focused_monitor:
                 args += [focused_monitor["name"], "-f", str(round(focused_monitor["refreshRate"]))]
 
-        if self.args.sound:
-            args += ["-a", "default_output"]
+        device = AUDIO_DEVICES.get(self.args.audio) or ("default_output" if self.args.sound else None)
+        if device:
+            args += ["-a", device]
 
         config = get_config()
         try:


### PR DESCRIPTION
Recording could only capture the focused monitor or a dragged region, and the only way to end one was to run `record` again and hope nothing else had toggled it in the meantime. This adds the pieces a front-end needs to drive the recorder directly.

> [!NOTE]
> Pairs with caelestia-dots/shell#1826, which puts these controls in the shell's utilities card. This PR stands on its own — the new flags are useful from a keybind or a terminal either way.

### `--mode {fullscreen,region,window}`

Window mode feeds `slurp` the geometry of every mapped window, so picking one is a **click rather than a freehand drag** over its edges. From there it reuses the existing region path, including matching the capture framerate to the fastest monitor the window covers.

### `--audio {none,system,mic,combined}`

Maps onto the PipeWire default aliases `gpu-screen-recorder` already understands (`default_output`, `default_input`, and the two combined), so there is no device enumeration to go stale.

### `--stop`

Ends a recording without the toggle guesswork. A front-end that already knows a recording is running should be able to say so, rather than sending a toggle and hoping.

### Also

Cancelling out of `slurp` now returns instead of raising a `CalledProcessError` traceback — backing out of a region or window selection is a normal thing to do, not an error.

Existing flags are untouched: bare `record` still toggles, and `-r`/`-s`/`-c` behave exactly as before. Fish completions updated for the new flags, plus `-p`/`--pause` which was previously missing.

### Testing

Verified against live Hyprland: fullscreen and region capture, and each audio mode producing the expected `gpu-screen-recorder` invocation. An end-to-end `--audio system` run followed by `--stop` produced a valid file — h264 1920x1080 video with an opus audio track — saved to the recordings directory. Window mode needs interactive selection, so it was checked by inspection of the region it hands off rather than automated.
