### PR TITLE
feat(templates): update Vencord theme to use the actual logo + sizing options

### DIFF
--- a/src/caelestia/data/templates/discord.scss
+++ b/src/caelestia/data/templates/discord.scss
@@ -45,8 +45,9 @@ body {
 
     /* dms button icon options */
     --custom-dms-icon: custom; /* off: use default discord icon, hide: remove icon entirely, custom: use custom icon */
-    --dms-icon-svg-url: url("https://refact0r.github.io/midnight-discord/assets/Font_Awesome_5_solid_moon.svg"); /* icon svg url. MUST BE A SVG. */
-    --dms-icon-svg-size: 90%; /* size of the svg (css mask-size) */
+    --dms-icon-svg-url: url("https://raw.githubusercontent.com/caelestia-dots/shell/refs/heads/main/assets/logo.svg"); /* icon svg url. MUST BE A SVG. */
+    --dms-icon-svg-size: 110%; /* size of the svg (css mask-size) */
+    --dms-icon-svg-size-after: 110%;
     --dms-icon-color-before: var(--icon-subtle); /* normal icon color */
     --dms-icon-color-after: var(--white); /* icon color when button is hovered/selected */
 
@@ -173,4 +174,12 @@ body {
     --purple-3: #{color.scale(c.$mauve, $lightness: -10%)};
     --purple-4: #{color.scale(c.$mauve, $lightness: -15%)};
     --purple-5: #{color.scale(c.$mauve, $lightness: -20%)};
+}
+
+@container body style(--custom-dms-icon: custom) {
+
+    .wrapper__6e9f8[data-list-item-id='guildsnav___home'].selected__6e9f8 > .childWrapper__6e9f8::before {
+        background: var(--dms-icon-color-after);
+        transform: rotate(-360deg) scale(var(--dms-icon-svg-size-after));
+    }
 }


### PR DESCRIPTION
I only updatedd the svg and added a field called '--dms-icon-svg-size-after' which allows you to set the icons scale after the aniomation. Also set default scaling to 110% as that fits the original size the best