### PR TITLE
fix(theme): stop apply_chromium from spamming on every theme change

### DIFF
--- a/src/caelestia/utils/theme.py
+++ b/src/caelestia/utils/theme.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from caelestia.utils.colour import get_dynamic_colours
 from caelestia.utils.hypr import is_lua_config
-from caelestia.utils.io import log_exception
+from caelestia.utils.io import log_exception, warn
 from caelestia.utils.paths import (
     atomic_write,
     c_state_dir,
@@ -344,13 +344,28 @@ def apply_warp(colours: dict[str, str], mode: str) -> None:
 
 @log_exception
 def apply_chromium(colours: dict[str, str]) -> None:
-    surface_hex = colours["surface"]
-    theme_color = f"#{surface_hex}"
     browsers = [
         ("chromium", Path("/etc/chromium/policies/managed")),
         ("brave", Path("/etc/brave/policies/managed")),
         ("google-chrome-stable", Path("/etc/opt/chrome/policies/managed")),
     ]
+    if not any(shutil.which(cmd) for cmd, _ in browsers):
+        return
+
+    # Writing the policy needs root, via a passwordless `sudo -n`. Almost no
+    # one sets that up for this specific case, so check once up front rather
+    # than attempting-and-warning per installed browser on every theme
+    # change -- that's expected, not an error, and shouldn't be noisy.
+    if (
+        subprocess.run(
+            ["sudo", "-n", "true"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False
+        ).returncode
+        != 0
+    ):
+        return
+
+    surface_hex = colours["surface"]
+    theme_color = f"#{surface_hex}"
 
     for cmd, policy_dir in browsers:
         if shutil.which(cmd) is None:
@@ -358,7 +373,7 @@ def apply_chromium(colours: dict[str, str]) -> None:
         if not policy_dir.is_dir():
             subprocess.run(["sudo", "-n", "mkdir", "-p", str(policy_dir)], stderr=subprocess.DEVNULL)
         if not policy_dir.is_dir():
-            print(f"Unable to create {policy_dir} directory")
+            warn(f"unable to create {policy_dir} directory")
             continue
 
         # Use tee instead of atomic_write cause we need sudo


### PR DESCRIPTION
## What

`apply_colours()` runs `apply_chromium()` for every user by default — `enableChromium` isn't in the default config schema, so `check("enableChromium")` treats the absent key as `true`. `apply_chromium()` writes the browser theme policy via `sudo -n mkdir`/`sudo -n tee`, which almost nobody has passwordless sudo configured for. The practical result on any stock install with Chromium/Brave/Chrome installed: every single wallpaper or scheme change prints a bare `Unable to create /etc/.../policies/managed directory` line, once per installed browser, forever — indistinguishable from a real error.

Related to #70.

## Fix

Check `sudo -n true` once up front, before touching any browser, and return quietly if it's not available — that's an expected, common state (no sudoers entry for this), not a failure worth reporting on every theme change. Kept a real warning (via the project's own `warn()` helper instead of a bare `print`) for the directory-creation failing for some *other* reason once sudo access is actually available, so genuine problems still surface.

This doesn't attempt to fully wire up Chromium theming (still needs a manual sudoers entry to actually work, same as before) — just makes the "not configured for it" case silent instead of noisy every time, since that's the default experience for effectively everyone right now.

## Testing

`uvx ruff check`/`uvx ruff format --check` both clean against this change — checked against the pristine unmodified file first to confirm baseline: `ruff check` reports 14 pre-existing errors elsewhere in this file on unmodified `main` (unrelated to this change), and this diff doesn't add to that count.