### PR TITLE
fix(wallpaper): case-sensitive extension check

### DIFF
--- a/src/caelestia/utils/wallpaper.py
+++ b/src/caelestia/utils/wallpaper.py
@@ -26,7 +26,7 @@ from caelestia.utils.theme import apply_colours
 
 
 def is_valid_image(path: Path) -> bool:
-    return path.is_file() and path.suffix in [".jpg", ".jpeg", ".png", ".webp", ".tif", ".tiff", ".gif"]
+    return path.is_file() and path.suffix.lower() in [".jpg", ".jpeg", ".png", ".webp", ".tif", ".tiff", ".gif"]
 
 
 def check_wall(wall: Path, filter_size: tuple[int, int], threshold: float) -> bool:


### PR DESCRIPTION
is_valid_image compared `path.suffix` (case-preserved) against a lowercase-only extension list, so a wallpaper file named e.g. `.JPG` or `.PNG` (common from phone cameras/screenshots) was rejected and `set_wallpaper` raised before writing `wallpaper_path_path` -- silently failing to persist the wallpaper. Lowercases the suffix before comparing.

Tested: reproduced by copying a `.jpg` to `.JPG` and running `caelestia wallpaper -f`, confirmed it failed before the fix and succeeds after.