### PR TITLE
feat(theme): support Brave Origin

### DIFF
--- a/src/caelestia/utils/theme.py
+++ b/src/caelestia/utils/theme.py
@@ -347,12 +347,14 @@ def apply_chromium(colours: dict[str, str]) -> None:
     surface_hex = colours["surface"]
     theme_color = f"#{surface_hex}"
     browsers = [
-        ("chromium", Path("/etc/chromium/policies/managed")),
-        ("brave", Path("/etc/brave/policies/managed")),
-        ("google-chrome-stable", Path("/etc/opt/chrome/policies/managed")),
+        ("chromium", Path("/etc/chromium/policies/managed"), True),
+        ("brave", Path("/etc/brave/policies/managed"), True),
+        # Brave and Brave Origin share a policy directory, so keep Origin last.
+        ("brave-origin", Path("/etc/brave/policies/managed"), False),
+        ("google-chrome-stable", Path("/etc/opt/chrome/policies/managed"), True),
     ]
 
-    for cmd, policy_dir in browsers:
+    for cmd, policy_dir, supports_color_scheme in browsers:
         if shutil.which(cmd) is None:
             continue
         if not policy_dir.is_dir():
@@ -362,9 +364,12 @@ def apply_chromium(colours: dict[str, str]) -> None:
             continue
 
         # Use tee instead of atomic_write cause we need sudo
+        policy = {"BrowserThemeColor": theme_color}
+        if supports_color_scheme:
+            policy["BrowserColorScheme"] = "device"
         subprocess.run(
             ["sudo", "-n", "tee", str(policy_dir / "caelestia.json")],
-            input=json.dumps({"BrowserThemeColor": theme_color, "BrowserColorScheme": "device"}),
+            input=json.dumps(policy),
             text=True,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,


### PR DESCRIPTION
## What

- Detect the official `brave-origin` launcher in `apply_chromium()`.
- Reuse Brave's `/etc/brave/policies/managed` directory.
- Write only `BrowserThemeColor` when Brave Origin is installed, because Origin reports `BrowserColorScheme` as an unknown policy.
- Keep Origin after standard Brave so the compatible payload wins when both are installed and share the same policy directory.

## Why

Brave Origin is a standalone Brave build whose Linux package installs `brave-origin`. Caelestia currently checks only `brave`, so Origin is skipped entirely.

The existing `BrowserThemeColor` policy and `--refresh-platform-policy --no-startup-window` command work with Origin and update its browser chrome without a restart.

Related to #70.

## Testing

- Mocked Origin-only, Brave-only, and combined Brave + Origin cases; verified command selection, policy path, payload, ordering, and refresh command.
- `python -m compileall -q src`
- `uvx ruff format --check src/caelestia/utils/theme.py`
- `git diff --check`
- Ruff reports the same 14 pre-existing findings in `theme.py` as unmodified `main`.
- Live-tested with Brave Origin 152.1.94.117 on Linux: `brave://policy` accepted the changing `BrowserThemeColor`, the chrome updated live, and the browser process did not restart.
