### PR TITLE
ci: use bypass app for push workflows

### DIFF
--- a/.github/workflows/update-emojis.yml
+++ b/.github/workflows/update-emojis.yml
@@ -11,14 +11,17 @@ jobs:
   update:
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: write
-
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout as app
+        uses: caelestia-dots/.github/actions/app-checkout@main
+        with:
+          client-id: ${{ secrets.CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          commit-add: src/caelestia/data/emojis.txt
+          commit-message: "chore(emoji): update emoji data [CI]"
 
       - name: Setup python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.x"
 
@@ -29,15 +32,3 @@ jobs:
 
       - name: Fetch emojis
         run: ./bin/caelestia emoji -f
-
-      - name: Check for changes
-        id: check
-        run: echo modified=$(git diff --exit-code src/caelestia/data/emojis.txt &>/dev/null && echo 'false' || echo 'true') >> $GITHUB_OUTPUT
-
-      - name: Commit and push changes
-        if: steps.check.outputs.modified == 'true'
-        uses: EndBug/add-and-commit@v9
-        with:
-          add: src/caelestia/data/emojis.txt
-          default_author: github_actions
-          message: "chore(emoji): update emoji data [CI]"

--- a/.github/workflows/update-flake-inputs.yml
+++ b/.github/workflows/update-flake-inputs.yml
@@ -9,47 +9,13 @@ jobs:
   update-flake:
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: write
-
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Nix
-        uses: nixbuild/nix-quick-install-action@v31
-        with:
-          nix_conf: |
-            keep-env-derivations = true
-            keep-outputs = true
-
-      - name: Restore and save Nix store
-        uses: nix-community/cache-nix-action@v6
-        with:
-          # restore and save a cache using this key
-          primary-key: nix-${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          # if there's no cache hit, restore a cache by this prefix
-          restore-prefixes-first-match: nix-
-          # collect garbage until the Nix store size (in bytes) is at most this number
-          # before trying to save a new cache
-          # 1G = 1073741824
-          gc-max-store-size-linux: 1G
-          # do purge caches
-          purge: true
-          # purge all versions of the cache
-          purge-prefixes: nix-
-          # created more than this number of seconds ago
-          purge-created: 0
-          # or, last accessed more than this number of seconds ago
-          # relative to the start of the `Post Restore and save Nix store` phase
-          purge-last-accessed: 0
-          # except any version with the key that is the same as the `primary-key`
-          purge-primary-key: never
-
       - name: Update flake inputs
-        run: nix flake update
-
-      - name: Attempt to build flake
-        run: nix build '.#with-shell'
+        uses: caelestia-dots/.github/actions/nix-update@main
+        with:
+          client-id: ${{ secrets.CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          package: with-shell
 
       - name: Test modules
         run: |
@@ -97,15 +63,3 @@ jobs:
           pgrep .quickshell-wra  # Fail job if shell died
           result/bin/caelestia shell -k
           killall sway  # Screw using IPC
-
-      - name: Check for changes
-        id: check
-        run: echo modified=$(git diff --exit-code flake.lock &>/dev/null && echo 'false' || echo 'true') >> $GITHUB_OUTPUT
-
-      - name: Commit and push changes
-        if: steps.check.outputs.modified == 'true'
-        uses: EndBug/add-and-commit@v9
-        with:
-          add: flake.lock
-          default_author: github_actions
-          message: "chore(nix): update flake inputs [CI]"


### PR DESCRIPTION
To fix push failures due to rulesets
Also bumps the versions of actions used