### PR TITLE
feat(scheme): support manual dynamic source colour

### DIFF
--- a/src/caelestia/parser.py
+++ b/src/caelestia/parser.py
@@ -64,6 +64,9 @@ def parse_args() -> tuple[argparse.ArgumentParser, argparse.Namespace]:
     get_parser.add_argument("-f", "--flavour", action="store_true", help="print the current scheme flavour")
     get_parser.add_argument("-m", "--mode", action="store_true", help="print the current scheme mode")
     get_parser.add_argument("-v", "--variant", action="store_true", help="print the current scheme variant")
+    get_parser.add_argument(
+        "-c", "--colour", "--color", action="store_true", help="print the source colour or auto"
+    )
 
     set_parser = scheme_command_parser.add_parser("set", help="set the current scheme")
     set_parser.set_defaults(cls=scheme.Set)
@@ -73,6 +76,10 @@ def parse_args() -> tuple[argparse.ArgumentParser, argparse.Namespace]:
     set_parser.add_argument("-f", "--flavour", help="the flavour to switch to")
     set_parser.add_argument("-m", "--mode", choices=["dark", "light"], help="the mode to switch to")
     set_parser.add_argument("-v", "--variant", choices=scheme_variants, help="the variant to switch to")
+    set_parser.add_argument("-c", "--colour", "--color", help="use a hexadecimal colour as the palette source")
+    set_parser.add_argument(
+        "--auto-colour", "--auto-color", action="store_true", help="derive the source colour from the wallpaper"
+    )
 
     # Create parser for screenshot opts
     screenshot_parser = command_parser.add_parser("screenshot", help="take a screenshot")

--- a/src/caelestia/subcommands/scheme.py
+++ b/src/caelestia/subcommands/scheme.py
@@ -27,9 +27,22 @@ class Set:
         if self.args.random:
             scheme.set_random()
             apply_colours(scheme.colours, scheme.mode)
-        elif self.args.name or self.args.flavour or self.args.mode or self.args.variant:
+        elif (
+            self.args.name
+            or self.args.flavour
+            or self.args.mode
+            or self.args.variant
+            or self.args.colour is not None
+            or self.args.auto_colour
+        ):
             if self.args.name:
                 scheme.name = self.args.name
+                if self.args.name == "dynamic" and self.args.colour is None and not self.args.auto_colour:
+                    scheme.clear_source_colour()
+            if self.args.colour is not None:
+                scheme.set_source_colour(self.args.colour)
+            elif self.args.auto_colour:
+                scheme.clear_source_colour()
             if self.args.flavour:
                 scheme.flavour = self.args.flavour
             if self.args.mode:
@@ -38,7 +51,10 @@ class Set:
                 scheme.variant = self.args.variant
             apply_colours(scheme.colours, scheme.mode)
         else:
-            print("No args given. Use --name, --flavour, --mode, --variant or --random to set a scheme")
+            print(
+                "No args given. Use --name, --flavour, --mode, --variant, "
+                "--colour, --auto-colour or --random to set a scheme"
+            )
 
 
 class Get:
@@ -50,7 +66,7 @@ class Get:
     def run(self) -> None:
         scheme = get_scheme()
 
-        if self.args.name or self.args.flavour or self.args.mode or self.args.variant:
+        if self.args.name or self.args.flavour or self.args.mode or self.args.variant or self.args.colour:
             if self.args.name:
                 print(scheme.name)
             if self.args.flavour:
@@ -59,6 +75,8 @@ class Get:
                 print(scheme.mode)
             if self.args.variant:
                 print(scheme.variant)
+            if self.args.colour:
+                print(scheme.source_colour or "auto")
         else:
             print(scheme)
 

--- a/src/caelestia/utils/scheme.py
+++ b/src/caelestia/utils/scheme.py
@@ -12,6 +12,7 @@ class Scheme:
     _flavour: str
     _mode: str
     _variant: str
+    _source_colour: str | None
     _colours: dict[str, str]
     notify: bool
 
@@ -21,12 +22,15 @@ class Scheme:
             self._flavour = "mocha"
             self._mode = "dark"
             self._variant = "tonalspot"
+            self._source_colour = None
             self._colours = read_colours_from_file(self.get_colours_path())
         else:
             self._name = scheme_json["name"]
             self._flavour = scheme_json["flavour"]
             self._mode = scheme_json["mode"]
             self._variant = scheme_json["variant"]
+            source_colour = scheme_json.get("sourceColour")
+            self._source_colour = self.normalise_colour(source_colour) if source_colour else None
             self._colours = scheme_json["colours"]
         self.notify = False
 
@@ -50,6 +54,8 @@ class Scheme:
             raise ValueError(f"Invalid scheme name: {name}")
 
         self._name = name
+        if name != "dynamic":
+            self._source_colour = None
         self._check_flavour()
         self._check_mode()
         self._update_colours()
@@ -117,6 +123,38 @@ class Scheme:
     def colours(self) -> dict[str, str]:
         return self._colours
 
+    @property
+    def source_colour(self) -> str | None:
+        return self._source_colour
+
+    @staticmethod
+    def normalise_colour(colour: str) -> str:
+        value = colour.strip().removeprefix("#")
+        if len(value) == 3:
+            value = "".join(c * 2 for c in value)
+        if len(value) != 6 or any(c not in "0123456789abcdefABCDEF" for c in value):
+            raise ValueError(f'Invalid colour: "{colour}". Expected a 6-digit hexadecimal colour.')
+        return value.lower()
+
+    def set_source_colour(self, colour: str) -> None:
+        try:
+            self._source_colour = self.normalise_colour(colour)
+        except ValueError as exc:
+            if self.notify:
+                notify("-u", "critical", "Unable to set colour", str(exc))
+            raise
+
+        self._name = "dynamic"
+        self._check_flavour()
+        self._check_mode()
+        self.update_colours()
+
+    def clear_source_colour(self) -> None:
+        if self._source_colour is None:
+            return
+        self._source_colour = None
+        self.update_colours()
+
     def get_colours_path(self) -> Path:
         return (scheme_data_dir / self.name / self.flavour / self.mode).with_suffix(".txt")
 
@@ -129,11 +167,13 @@ class Scheme:
                 "flavour": self.flavour,
                 "mode": self.mode,
                 "variant": self.variant,
+                "sourceColour": self.source_colour,
                 "colours": self.colours,
             },
         )
 
     def set_random(self) -> None:
+        self._source_colour = None
         self._name = random.choice(get_scheme_names())
         self._flavour = random.choice(get_scheme_flavours(self.name))
         self._mode = random.choice(get_scheme_modes(self.name, self.flavour))
@@ -158,7 +198,12 @@ class Scheme:
             from caelestia.utils.material import get_colours_for_image
 
             try:
-                self._colours = get_colours_for_image()
+                if self.source_colour:
+                    from caelestia.utils.material.generator import gen_scheme, hex_to_hct
+
+                    self._colours = gen_scheme(self, hex_to_hct(self.source_colour))
+                else:
+                    self._colours = get_colours_for_image()
             except FileNotFoundError:
                 if self.notify:
                     notify(


### PR DESCRIPTION
## Problem
The shell needs a stable way to let users choose the source colour for the dynamic Material palette. The CLI only supported selecting a named scheme, flavour, mode, or variant, so a UI could not persist a manual accent colour.

## Change
- Add optional `sourceColour` state to `scheme.json`.
- Add `scheme set --colour HEX` with `#RGB` and `#RRGGBB` support.
- Add `scheme set --auto-colour` to return dynamic schemes to wallpaper-derived colours.
- Add `scheme get --colour` / `--color` for scripts and the shell UI.
- Preserve the manual source while changing dynamic mode or variant.
- Clear it when switching to a named preset or a random scheme.
- Generate the same complete Material role set through the existing dynamic scheme pipeline.

## Validation
- Built the wheel successfully on the current `main` checkout.
- Ran Python bytecode compilation and `git diff --check`.
- Ran an isolated XDG-state test covering manual colour application, state persistence, 3/6-digit HEX normalization, variant changes, and generated roles.
- Verified `scheme get --colour` returns only the source colour.

The companion shell PR adds the Nexus UI for this functionality.
